### PR TITLE
Cover lazy Chat Goal continuation

### DIFF
--- a/server/core/core_test.go
+++ b/server/core/core_test.go
@@ -15,6 +15,7 @@ import (
 	"core/server/auth"
 	serverbootstrap "core/server/bootstrap"
 	"core/server/metadata"
+	"core/server/runtimewire"
 	"core/server/session"
 	"core/server/session/sessiontest"
 	"core/server/sessionlaunch"
@@ -946,7 +947,7 @@ func TestSessionLaunchClientForProjectWorkspaceRejectsInaccessibleProjectRoot(t 
 	}
 }
 
-func newCoreTestApp(t *testing.T, cfg brand.App, state auth.State) *Core {
+func newCoreTestApp(t *testing.T, cfg brand.App, state auth.State, factories ...runtimewire.RuntimeClientFactory) *Core {
 	t.Helper()
 	authSupport, err := serverbootstrap.BuildAuthSupport(auth.NewMemoryStore(state), nil, nil)
 	if err != nil {
@@ -957,9 +958,19 @@ func newCoreTestApp(t *testing.T, cfg brand.App, state auth.State) *Core {
 		t.Fatalf("BuildRuntimeSupport: %v", err)
 	}
 	t.Cleanup(func() { _ = runtimeSupport.Background.Close() })
-	appCore, err := New(cfg, authSupport, runtimeSupport)
+	var appCore *Core
+	switch len(factories) {
+	case 0:
+		appCore, err = New(cfg, authSupport, runtimeSupport)
+	case 1:
+		appCore, err = NewWithContextOptions(t.Context(), cfg, authSupport, runtimeSupport, Options{
+			RuntimeClientFactory: factories[0],
+		})
+	default:
+		t.Fatalf("newCoreTestApp received %d runtime client factories, want at most one", len(factories))
+	}
 	if err != nil {
-		t.Fatalf("New: %v", err)
+		t.Fatalf("create Core: %v", err)
 	}
 	t.Cleanup(func() { _ = appCore.Close() })
 	return appCore

--- a/server/core/core_test.go
+++ b/server/core/core_test.go
@@ -557,18 +557,8 @@ func TestCoreMaterializesWorkspaceChatAtServerBoundary(t *testing.T) {
 		t.Fatalf("cleared lazy Chat exposed Sessions: %+v", page.Sessions)
 	}
 
-	draft := metadata.WorkspaceChatDraftDocument{
-		Message:        "unsent complete draft",
-		Agent:          "default",
-		Supervisor:     "all",
-		Thinking:       "medium",
-		Fast:           true,
-		Questions:      false,
-		AutoCompaction: false,
-	}
-	if err := appCore.MetadataStore().ReplaceWorkspaceChatDraft(t.Context(), binding.WorkspaceID, &draft); err != nil {
-		t.Fatalf("ReplaceWorkspaceChatDraft: %v", err)
-	}
+	draft := workspaceChatDraft("unsent complete draft", false)
+	persistWorkspaceChatDraft(t, appCore, binding, draft)
 	materialized, err := client.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
 	if err != nil {
 		t.Fatalf("MaterializeWorkspaceChat: %v", err)
@@ -652,6 +642,24 @@ func TestCoreMaterializesWorkspaceChatAtServerBoundary(t *testing.T) {
 	}
 	if page := list(); len(page.Sessions) != 2 {
 		t.Fatalf("ignored committed response list = %+v, want two Sessions", page.Sessions)
+	}
+}
+
+func workspaceChatDraft(message string, questions bool) metadata.WorkspaceChatDraftDocument {
+	return metadata.WorkspaceChatDraftDocument{
+		Message:        message,
+		Agent:          brand.DefaultSubagentRole,
+		Supervisor:     "all",
+		Thinking:       "medium",
+		Fast:           true,
+		Questions:      questions,
+		AutoCompaction: false,
+	}
+}
+
+func persistWorkspaceChatDraft(t *testing.T, appCore *Core, binding metadata.Binding, draft metadata.WorkspaceChatDraftDocument) {
+	if err := appCore.MetadataStore().ReplaceWorkspaceChatDraft(t.Context(), binding.WorkspaceID, &draft); err != nil {
+		t.Fatalf("ReplaceWorkspaceChatDraft: %v", err)
 	}
 }
 

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -62,6 +62,7 @@ type lazyGoalFixture struct {
 	materialized serverapi.WorkspaceChatMaterializeResponse
 	planned      serverapi.SessionPlanResponse
 	activation   serverapi.SessionRuntimeActivateResponse
+	ownerID      string
 	released     bool
 }
 
@@ -154,7 +155,7 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	if len(page.Sessions) != 1 {
 		t.Fatalf("materialized Session list = %+v, want one", page.Sessions)
 	}
-	fixture.release(t, "lazy-goal")
+	fixture.release(t)
 }
 
 func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *testing.T) {
@@ -185,7 +186,7 @@ func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *tes
 	}
 	fixture.requireNoTranscript(t)
 	fixture.requireOneSession(t)
-	fixture.release(t, "lazy-capability")
+	fixture.release(t)
 }
 
 func TestCoreLazyChatGoalAdmissionRejectionRetainsMaterializedSession(t *testing.T) {
@@ -271,7 +272,7 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	fixture.release(t, "lazy-failure")
+	fixture.release(t)
 	client.mu.Lock()
 	calls := client.calls
 	client.mu.Unlock()
@@ -286,12 +287,10 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 		t.Fatalf("durable Goal = %+v, want accepted active Goal", record.Meta.Goal)
 	}
 	fixture.requireDraftAndTranscript(t, nil)
+	fixture.requireOneSession(t)
 }
 
-func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) (*Core, metadata.Binding, interface {
-	PlanSession(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error)
-	MaterializeWorkspaceChat(context.Context, serverapi.WorkspaceChatMaterializeRequest) (serverapi.WorkspaceChatMaterializeResponse, error)
-}) {
+func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) (*Core, metadata.Binding, lazyGoalLaunchClient) {
 	t.Helper()
 	workspace := t.TempDir()
 	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{
@@ -336,7 +335,7 @@ func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client 
 		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
 			ClientRequestID: "lazy-goal-release-cleanup",
 			Attachment:      fixture.activation.Attachment,
-			OwnerID:         "lazy-goal-cleanup",
+			OwnerID:         fixture.ownerID,
 			DropOwner:       true,
 		})
 	})
@@ -364,10 +363,11 @@ func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
 		t.Fatalf("PlanSession: %v", err)
 	}
 	f.planned = planned
+	f.ownerID = prefix + "-owner"
 	activation, err := f.appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
 		ClientRequestID:          prefix + "-activate",
 		SessionID:                f.materialized.SessionID.String(),
-		OwnerID:                  prefix + "-owner",
+		OwnerID:                  f.ownerID,
 		ActiveSettings:           planned.Plan.ActiveSettings,
 		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
 		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
@@ -381,12 +381,12 @@ func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
 	f.activation = activation
 }
 
-func (f *lazyGoalFixture) release(t *testing.T, ownerID string) {
+func (f *lazyGoalFixture) release(t *testing.T) {
 	t.Helper()
 	response, err := f.appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
 		ClientRequestID: "lazy-goal-release",
 		Attachment:      f.activation.Attachment,
-		OwnerID:         ownerID,
+		OwnerID:         f.ownerID,
 		DropOwner:       true,
 	})
 	if err != nil {
@@ -411,25 +411,13 @@ func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *i
 	if state.Message != f.draft.Message {
 		t.Fatalf("composer draft = %q, want %q", state.Message, f.draft.Message)
 	}
-	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
+	records := f.collectMessageRecords(t, record.SessionDir)
 	if wantRecords != nil && len(records) != *wantRecords {
 		t.Fatalf("materialized transcript records = %d, want %d", len(records), *wantRecords)
 	}
 	for _, event := range records {
-		payload, payloadErr := event.Payload()
-		if payloadErr != nil {
-			t.Fatalf("event payload: %v", payloadErr)
-		}
-		message, ok := payload.(session.MessageRecord)
-		if ok && message.Role == session.MessageRoleUser {
-			t.Fatalf("materialized transcript contains user message: %+v", message)
+		if event.Role == session.MessageRoleUser {
+			t.Fatalf("materialized transcript contains user message: %+v", event)
 		}
 	}
 }
@@ -446,24 +434,10 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
 	}
-	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
+	records := f.collectMessageRecords(t, record.SessionDir)
 	goalNotices, userMessages := 0, 0
 	for _, event := range records {
-		payload, payloadErr := event.Payload()
-		if payloadErr != nil {
-			t.Fatalf("event payload: %v", payloadErr)
-		}
-		message, ok := payload.(session.MessageRecord)
-		if !ok {
-			continue
-		}
+		message := event
 		if message.MessageType != nil && *message.MessageType == session.MessageTypeGoal {
 			goalNotices++
 		}
@@ -474,6 +448,30 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	if goalNotices != 1 || userMessages != 0 {
 		t.Fatalf("materialized Goal records = notices:%d user_messages:%d, want one notice and no user message", goalNotices, userMessages)
 	}
+}
+
+func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string) []session.MessageRecord {
+	t.Helper()
+	store, err := session.Open(sessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	messages := make([]session.MessageRecord, 0, len(records))
+	for _, event := range records {
+		payload, payloadErr := event.Payload()
+		if payloadErr != nil {
+			t.Fatalf("event payload: %v", payloadErr)
+		}
+		message, ok := payload.(session.MessageRecord)
+		if ok {
+			messages = append(messages, message)
+		}
+	}
+	return messages
 }
 
 func (f *lazyGoalFixture) requireOneSession(t *testing.T) {

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
 	"core/shared/sessioncontract"
+	"core/shared/textutil"
 	"core/shared/toolspec"
 )
 
@@ -61,7 +63,7 @@ type lazyGoalFixture struct {
 	draft        metadata.WorkspaceChatDraftDocument
 	materialized serverapi.WorkspaceChatMaterializeResponse
 	planned      serverapi.SessionPlanResponse
-	activation   serverapi.SessionRuntimeActivateResponse
+	activation   *serverapi.SessionRuntimeActivateResponse
 	ownerID      string
 	released     bool
 }
@@ -94,7 +96,7 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
 		ProjectID: binding.ProjectID,
 		Category:  sessioncontract.SessionCategoryMain,
-		Limit:     intPointer(20),
+		Limit:     textutil.Value(20),
 	})
 	if err != nil {
 		t.Fatalf("ListSessionPage before materialization: %v", err)
@@ -147,7 +149,7 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	page, err = appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
 		ProjectID: binding.ProjectID,
 		Category:  sessioncontract.SessionCategoryMain,
-		Limit:     intPointer(20),
+		Limit:     textutil.Value(20),
 	})
 	if err != nil {
 		t.Fatalf("ListSessionPage after Goal: %v", err)
@@ -164,7 +166,7 @@ func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *tes
 	fixture.materializeAndActivate(t, "lazy-capability")
 	materialized := fixture.materialized
 	appCore := fixture.appCore
-	if containsTool(fixture.planned.Plan.EnabledToolIDs, string(toolspec.ToolAskQuestion)) {
+	if slices.Contains(fixture.planned.Plan.EnabledToolIDs, string(toolspec.ToolAskQuestion)) {
 		t.Fatalf("planned materialized tool contract unexpectedly enables ask_question: %v", fixture.planned.Plan.EnabledToolIDs)
 	}
 
@@ -327,7 +329,7 @@ func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client 
 		draft:   writeLazyGoalDraft(t, appCore, binding),
 	}
 	t.Cleanup(func() {
-		if fixture.released || fixture.activation.Attachment.SessionID == "" {
+		if fixture.released || fixture.activation == nil {
 			return
 		}
 		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
@@ -366,15 +368,15 @@ func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
 		OwnerID:                  f.ownerID,
 		ActiveSettings:           planned.Plan.ActiveSettings,
 		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
-		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
-		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
+		QuestionsEnabled:         textutil.Value(planned.Plan.QuestionsEnabled),
+		AutoCompactionEnabled:    textutil.Value(planned.Plan.AutoCompactionEnabled),
 		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
 		Source:                   planned.Plan.Source,
 	})
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	f.activation = activation
+	f.activation = &activation
 }
 
 func (f *lazyGoalFixture) release(t *testing.T) {
@@ -469,7 +471,7 @@ func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
 	page, err := f.appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
 		ProjectID: f.binding.ProjectID,
 		Category:  sessioncontract.SessionCategoryMain,
-		Limit:     intPointer(20),
+		Limit:     textutil.Value(20),
 	})
 	if err != nil {
 		t.Fatalf("ListSessionPage: %v", err)
@@ -493,21 +495,4 @@ func writeLazyGoalDraft(t *testing.T, appCore *Core, binding metadata.Binding) m
 		t.Fatalf("ReplaceWorkspaceChatDraft: %v", err)
 	}
 	return draft
-}
-
-func containsTool(tools []string, want string) bool {
-	for _, tool := range tools {
-		if tool == want {
-			return true
-		}
-	}
-	return false
-}
-
-func boolPointer(value bool) *bool {
-	return &value
-}
-
-func intPointer(value int) *int {
-	return &value
 }

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -326,8 +326,9 @@ func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client 
 		appCore: appCore,
 		binding: binding,
 		launch:  launch,
-		draft:   writeLazyGoalDraft(t, appCore, binding),
+		draft:   workspaceChatDraft("unsent composer draft", true),
 	}
+	persistWorkspaceChatDraft(t, appCore, binding, fixture.draft)
 	t.Cleanup(func() {
 		if fixture.released || fixture.activation == nil {
 			return
@@ -407,7 +408,14 @@ func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *i
 	if state.Message != f.draft.Message {
 		t.Fatalf("composer draft = %q, want %q", state.Message, f.draft.Message)
 	}
-	records, messages := f.collectMessageRecords(t, record.SessionDir)
+	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, messages, err := sessiontest.CollectRecordsAndMessages(store)
+	if err != nil {
+		t.Fatalf("collect message records: %v", err)
+	}
 	if wantRecords != nil && len(records) != *wantRecords {
 		t.Fatalf("materialized transcript records = %d, want %d", len(records), *wantRecords)
 	}
@@ -428,10 +436,16 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
 	}
-	_, records := f.collectMessageRecords(t, record.SessionDir)
+	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	_, messages, err := sessiontest.CollectRecordsAndMessages(store)
+	if err != nil {
+		t.Fatalf("collect message records: %v", err)
+	}
 	goalNotices, userMessages := 0, 0
-	for _, event := range records {
-		message := event
+	for _, message := range messages {
 		if message.MessageType != nil && *message.MessageType == session.MessageTypeGoal {
 			goalNotices++
 		}
@@ -442,29 +456,6 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	if goalNotices != 1 || userMessages != 0 {
 		t.Fatalf("materialized Goal records = notices:%d user_messages:%d, want one notice and no user message", goalNotices, userMessages)
 	}
-}
-
-func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string) ([]session.EventRecord, []session.MessageRecord) {
-	store, err := session.Open(sessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
-	messages := make([]session.MessageRecord, 0, len(records))
-	for _, event := range records {
-		payload, payloadErr := event.Payload()
-		if payloadErr != nil {
-			t.Fatalf("event payload: %v", payloadErr)
-		}
-		message, ok := payload.(session.MessageRecord)
-		if ok {
-			messages = append(messages, message)
-		}
-	}
-	return records, messages
 }
 
 func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
@@ -479,20 +470,4 @@ func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
 	if len(page.Sessions) != 1 {
 		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
 	}
-}
-
-func writeLazyGoalDraft(t *testing.T, appCore *Core, binding metadata.Binding) metadata.WorkspaceChatDraftDocument {
-	draft := metadata.WorkspaceChatDraftDocument{
-		Message:        "unsent composer draft",
-		Agent:          brand.DefaultSubagentRole,
-		Supervisor:     "all",
-		Thinking:       "medium",
-		Fast:           true,
-		Questions:      true,
-		AutoCompaction: false,
-	}
-	if err := appCore.MetadataStore().ReplaceWorkspaceChatDraft(t.Context(), binding.WorkspaceID, &draft); err != nil {
-		t.Fatalf("ReplaceWorkspaceChatDraft: %v", err)
-	}
-	return draft
 }

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -1,0 +1,582 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"core/server/auth"
+	serverbootstrap "core/server/bootstrap"
+	"core/server/llm"
+	"core/server/metadata"
+	"core/server/runtime"
+	"core/server/runtimewire"
+	"core/server/session"
+	"core/server/session/sessiontest"
+	"core/server/sessionruntime"
+	"core/shared/clientui"
+	brand "core/shared/config"
+	"core/shared/runtimeids"
+	"core/shared/serverapi"
+	"core/shared/sessioncontract"
+	"core/shared/toolspec"
+)
+
+type lazyGoalBlockingClient struct {
+	started     chan struct{}
+	startedOnce sync.Once
+}
+
+func (c *lazyGoalBlockingClient) Generate(ctx context.Context, _ llm.Request) (llm.Response, error) {
+	c.startedOnce.Do(func() { close(c.started) })
+	<-ctx.Done()
+	return llm.Response{}, context.Cause(ctx)
+}
+
+func (*lazyGoalBlockingClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
+	return llm.InferProviderCapabilities("openai")
+}
+
+type lazyGoalFailingClient struct {
+	started      chan struct{}
+	returned     chan struct{}
+	startedOnce  sync.Once
+	returnedOnce sync.Once
+	mu           sync.Mutex
+	calls        int
+	release      chan struct{}
+}
+
+func (c *lazyGoalFailingClient) Generate(ctx context.Context, _ llm.Request) (llm.Response, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	c.startedOnce.Do(func() { close(c.started) })
+	select {
+	case <-c.release:
+	case <-ctx.Done():
+		return llm.Response{}, context.Cause(ctx)
+	}
+	c.returnedOnce.Do(func() { close(c.returned) })
+	return llm.Response{}, &llm.AuthError{Err: auth.ErrAuthNotConfigured}
+}
+
+func (*lazyGoalFailingClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
+	return llm.InferProviderCapabilities("openai")
+}
+
+func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
+	blocking := &lazyGoalBlockingClient{started: make(chan struct{})}
+	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, blocking)
+	goalClient := appCore.RuntimeControlClient()
+
+	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		ProjectID: binding.ProjectID,
+		Category:  sessioncontract.SessionCategoryMain,
+		Limit:     intPointer(20),
+	})
+	if err != nil {
+		t.Fatalf("ListSessionPage before materialization: %v", err)
+	}
+	if len(page.Sessions) != 0 {
+		t.Fatalf("untouched lazy Chat exposed Sessions: %+v", page.Sessions)
+	}
+
+	draft := writeLazyGoalDraft(t, appCore, binding)
+	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+
+	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
+		ClientRequestID: "lazy-goal-plan",
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
+	})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if planned.Plan.SessionID != materialized.SessionID.String() {
+		t.Fatalf("planned Session = %q, want %q", planned.Plan.SessionID, materialized.SessionID)
+	}
+	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID:          "lazy-goal-activate",
+		SessionID:                materialized.SessionID.String(),
+		OwnerID:                  "lazy-goal-owner",
+		ActiveSettings:           planned.Plan.ActiveSettings,
+		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
+		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
+		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
+		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
+		Source:                   planned.Plan.Source,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	released := false
+	t.Cleanup(func() {
+		if released {
+			return
+		}
+		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+			ClientRequestID: "lazy-goal-release",
+			Attachment:      activation.Attachment,
+			OwnerID:         "lazy-goal-owner",
+			DropOwner:       true,
+		})
+	})
+
+	response, err := goalClient.SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "lazy-goal-set",
+		SessionID:       materialized.SessionID.String(),
+		Objective:       "ship the lazy Chat Goal",
+		Actor:           "user",
+	})
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	if response.Goal == nil || response.Goal.Objective != "ship the lazy Chat Goal" || response.Goal.Status != clientui.RuntimeGoalStatusActive {
+		t.Fatalf("SetGoal response = %+v, want active Goal", response)
+	}
+	select {
+	case <-blocking.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first model request")
+	}
+
+	record, err := appCore.MetadataStore().ResolvePersistedSession(t.Context(), materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	state, err := session.ChatDraftStateFromMeta(*record.Meta)
+	if err != nil {
+		t.Fatalf("ChatDraftStateFromMeta: %v", err)
+	}
+	if state.Message != draft.Message || state.Agent != draft.Agent ||
+		state.Settings == nil ||
+		*state.Settings.Supervisor != draft.Supervisor ||
+		*state.Settings.Thinking != draft.Thinking ||
+		*state.Settings.Fast != draft.Fast ||
+		*state.Settings.Questions != draft.Questions ||
+		*state.Settings.AutoCompaction != draft.AutoCompaction {
+		t.Fatalf("materialized Chat state = %+v, want %+v", state, draft)
+	}
+	if record.Meta.Goal == nil || record.Meta.Goal.Objective != response.Goal.Objective || record.Meta.Goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted Goal = %+v, want active Goal", record.Meta.Goal)
+	}
+	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	goalNotices := 0
+	userMessages := 0
+	for _, event := range records {
+		payload, payloadErr := event.Payload()
+		if payloadErr != nil {
+			t.Fatalf("event payload: %v", payloadErr)
+		}
+		message, ok := payload.(session.MessageRecord)
+		if !ok {
+			continue
+		}
+		if message.MessageType != nil && *message.MessageType == session.MessageTypeGoal {
+			goalNotices++
+		}
+		if message.Role == session.MessageRoleUser {
+			userMessages++
+		}
+	}
+	if goalNotices != 1 || userMessages != 0 {
+		t.Fatalf("materialized Goal records = notices:%d user_messages:%d, want one notice and no user message", goalNotices, userMessages)
+	}
+	page, err = appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		ProjectID: binding.ProjectID,
+		Category:  sessioncontract.SessionCategoryMain,
+		Limit:     intPointer(20),
+	})
+	if err != nil {
+		t.Fatalf("ListSessionPage after Goal: %v", err)
+	}
+	if len(page.Sessions) != 1 {
+		t.Fatalf("materialized Session list = %+v, want one", page.Sessions)
+	}
+	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "lazy-goal-release-explicit",
+		Attachment:      activation.Attachment,
+		OwnerID:         "lazy-goal-owner",
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if !releaseResponse.Released || releaseResponse.Active {
+		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
+	}
+	released = true
+}
+
+func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *testing.T) {
+	client := &lazyGoalBlockingClient{started: make(chan struct{})}
+	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolExecCommand: true}, client)
+	draft := writeLazyGoalDraft(t, appCore, binding)
+
+	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
+		ClientRequestID: "lazy-capability-plan",
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
+	})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if containsTool(planned.Plan.EnabledToolIDs, string(toolspec.ToolAskQuestion)) {
+		t.Fatalf("planned materialized tool contract unexpectedly enables ask_question: %v", planned.Plan.EnabledToolIDs)
+	}
+	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID:          "lazy-capability-activate",
+		SessionID:                materialized.SessionID.String(),
+		OwnerID:                  "lazy-capability-owner",
+		ActiveSettings:           planned.Plan.ActiveSettings,
+		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
+		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
+		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
+		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
+		Source:                   planned.Plan.Source,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	released := false
+	t.Cleanup(func() {
+		if released {
+			return
+		}
+		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+			ClientRequestID: "lazy-capability-release",
+			Attachment:      activation.Attachment,
+			OwnerID:         "lazy-capability-owner",
+			DropOwner:       true,
+		})
+	})
+
+	_, err = appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "lazy-capability-set",
+		SessionID:       materialized.SessionID.String(),
+		Objective:       "this must be rejected",
+		Actor:           "user",
+	})
+	if !errors.Is(err, runtime.ErrGoalRequiresAskQuestion) {
+		t.Fatalf("SetGoal error = %v, want ErrGoalRequiresAskQuestion", err)
+	}
+	record, err := appCore.MetadataStore().ResolvePersistedSession(t.Context(), materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	if record.Meta.Goal != nil {
+		t.Fatalf("rejected capability Goal persisted: %+v", record.Meta.Goal)
+	}
+	state, err := session.ChatDraftStateFromMeta(*record.Meta)
+	if err != nil {
+		t.Fatalf("ChatDraftStateFromMeta: %v", err)
+	}
+	if state.Message != draft.Message {
+		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
+	}
+	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("rejected capability created transcript records: %+v", records)
+	}
+	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		ProjectID: binding.ProjectID,
+		Category:  sessioncontract.SessionCategoryMain,
+		Limit:     intPointer(20),
+	})
+	if err != nil {
+		t.Fatalf("ListSessionPage: %v", err)
+	}
+	if len(page.Sessions) != 1 {
+		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
+	}
+	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "lazy-capability-release-explicit",
+		Attachment:      activation.Attachment,
+		OwnerID:         "lazy-capability-owner",
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if !releaseResponse.Released || releaseResponse.Active {
+		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
+	}
+	released = true
+}
+
+func TestCoreLazyChatGoalAdmissionRejectionRetainsMaterializedSession(t *testing.T) {
+	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, &lazyGoalBlockingClient{started: make(chan struct{})})
+	draft := writeLazyGoalDraft(t, appCore, binding)
+	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+	releaseBlock, err := appCore.safeBundles().Runtime.runtimeAuthority.BlockSessionStarts(
+		t.Context(),
+		[]runtimeids.SessionID{materialized.SessionID},
+		sessionruntime.SessionStartBlockMaintenance,
+	)
+	if err != nil {
+		t.Fatalf("BlockSessionStarts: %v", err)
+	}
+	t.Cleanup(func() { _ = releaseBlock.Close(context.Background()) })
+
+	_, err = appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "lazy-admission-set",
+		SessionID:       materialized.SessionID.String(),
+		Objective:       "valid nonblank objective",
+		Actor:           "user",
+	})
+	if !errors.Is(err, sessionruntime.ErrSessionStartsBlocked) {
+		t.Fatalf("SetGoal error = %v, want ErrSessionStartsBlocked", err)
+	}
+	record, err := appCore.MetadataStore().ResolvePersistedSession(t.Context(), materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	if record.Meta.Goal != nil {
+		t.Fatalf("admission-rejected Goal persisted: %+v", record.Meta.Goal)
+	}
+	state, err := session.ChatDraftStateFromMeta(*record.Meta)
+	if err != nil {
+		t.Fatalf("ChatDraftStateFromMeta: %v", err)
+	}
+	if state.Message != draft.Message {
+		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
+	}
+	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("admission rejection created transcript records: %+v", records)
+	}
+	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		ProjectID: binding.ProjectID,
+		Category:  sessioncontract.SessionCategoryMain,
+		Limit:     intPointer(20),
+	})
+	if err != nil {
+		t.Fatalf("ListSessionPage: %v", err)
+	}
+	if len(page.Sessions) != 1 {
+		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
+	}
+}
+
+func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
+	client := &lazyGoalFailingClient{
+		started:  make(chan struct{}),
+		returned: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, client)
+	draft := writeLazyGoalDraft(t, appCore, binding)
+	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
+		ClientRequestID: "lazy-failure-plan",
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
+	})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID:          "lazy-failure-activate",
+		SessionID:                materialized.SessionID.String(),
+		OwnerID:                  "lazy-failure-owner",
+		ActiveSettings:           planned.Plan.ActiveSettings,
+		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
+		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
+		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
+		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
+		Source:                   planned.Plan.Source,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	response, err := appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "lazy-failure-set",
+		SessionID:       materialized.SessionID.String(),
+		Objective:       "accepted before provider failure",
+		Actor:           "user",
+	})
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	if response.Goal == nil || response.Goal.Status != clientui.RuntimeGoalStatusActive {
+		t.Fatalf("SetGoal response = %+v, want active Goal", response)
+	}
+	select {
+	case <-client.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first model request")
+	}
+	close(client.release)
+	select {
+	case <-client.returned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for provider failure return")
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		view, viewErr := appCore.SessionViewClient().GetSessionMainView(t.Context(), serverapi.SessionMainViewRequest{
+			SessionID: materialized.SessionID.String(),
+		})
+		if viewErr == nil && view.MainView.Activity.State == clientui.RuntimeActivityRegisteredIdle {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("runtime did not settle idle after provider failure: view error=%v", viewErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "lazy-failure-release",
+		Attachment:      activation.Attachment,
+		OwnerID:         "lazy-failure-owner",
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if !releaseResponse.Released || releaseResponse.Active {
+		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
+	}
+	client.mu.Lock()
+	calls := client.calls
+	client.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("provider Generate calls = %d, want one", calls)
+	}
+	record, err := appCore.MetadataStore().ResolvePersistedSession(t.Context(), materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	if record.Meta.Goal == nil || record.Meta.Goal.ID != response.Goal.ID || record.Meta.Goal.Status != session.GoalStatusActive {
+		t.Fatalf("durable Goal = %+v, want accepted active Goal", record.Meta.Goal)
+	}
+	state, err := session.ChatDraftStateFromMeta(*record.Meta)
+	if err != nil {
+		t.Fatalf("ChatDraftStateFromMeta: %v", err)
+	}
+	if state.Message != draft.Message {
+		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
+	}
+}
+
+func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) (*Core, metadata.Binding, interface {
+	PlanSession(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error)
+	MaterializeWorkspaceChat(context.Context, serverapi.WorkspaceChatMaterializeRequest) (serverapi.WorkspaceChatMaterializeResponse, error)
+}) {
+	t.Helper()
+	workspace := t.TempDir()
+	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{
+		WorkspaceRoot: workspace,
+		LoadOptions:   brand.LoadOptions{ConfigRoot: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	resolved.Config.Settings.EnabledTools = enabledTools
+	resolved.Config.Settings.Model = "test-model"
+	resolved.Config.Settings.ModelContextWindow = 200000
+	binding, err := metadata.RegisterBinding(t.Context(), resolved.Config.PersistenceRoot, workspace)
+	if err != nil {
+		t.Fatalf("RegisterBinding: %v", err)
+	}
+	appCore := newCoreTestAppWithRuntimeFactory(t, resolved.Config, auth.EmptyState(), runtimewire.RuntimeClientFactoryFunc(
+		func(context.Context, runtimewire.RuntimeClientRequest) (llm.Client, error) {
+			return client, nil
+		},
+	))
+	launchClient, err := appCore.SessionLaunchClientForProjectWorkspace(t.Context(), binding.ProjectID, workspace)
+	if err != nil {
+		t.Fatalf("SessionLaunchClientForProjectWorkspace: %v", err)
+	}
+	return appCore, binding, launchClient
+}
+
+func writeLazyGoalDraft(t *testing.T, appCore *Core, binding metadata.Binding) metadata.WorkspaceChatDraftDocument {
+	t.Helper()
+	draft := metadata.WorkspaceChatDraftDocument{
+		Message:        "unsent composer draft",
+		Agent:          brand.DefaultSubagentRole,
+		Supervisor:     "all",
+		Thinking:       "medium",
+		Fast:           true,
+		Questions:      true,
+		AutoCompaction: false,
+	}
+	if err := appCore.MetadataStore().ReplaceWorkspaceChatDraft(t.Context(), binding.WorkspaceID, &draft); err != nil {
+		t.Fatalf("ReplaceWorkspaceChatDraft: %v", err)
+	}
+	return draft
+}
+
+func containsTool(tools []string, want string) bool {
+	for _, tool := range tools {
+		if tool == want {
+			return true
+		}
+	}
+	return false
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func newCoreTestAppWithRuntimeFactory(t *testing.T, cfg brand.App, state auth.State, factory runtimewire.RuntimeClientFactory) *Core {
+	t.Helper()
+	authSupport, err := serverbootstrap.BuildAuthSupport(auth.NewMemoryStore(state), nil, nil)
+	if err != nil {
+		t.Fatalf("BuildAuthSupport: %v", err)
+	}
+	runtimeSupport, err := serverbootstrap.BuildRuntimeSupport(cfg)
+	if err != nil {
+		t.Fatalf("BuildRuntimeSupport: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeSupport.Background.Close() })
+	appCore, err := NewWithContextOptions(t.Context(), cfg, authSupport, runtimeSupport, Options{RuntimeClientFactory: factory})
+	if err != nil {
+		t.Fatalf("NewWithContextOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = appCore.Close() })
+	return appCore
+}

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -405,11 +405,11 @@ func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *i
 	if state.Message != f.draft.Message {
 		t.Fatalf("composer draft = %q, want %q", state.Message, f.draft.Message)
 	}
-	records := f.collectMessageRecords(t, record.SessionDir)
+	records, messages := f.collectMessageRecords(t, record.SessionDir)
 	if wantRecords != nil && len(records) != *wantRecords {
 		t.Fatalf("materialized transcript records = %d, want %d", len(records), *wantRecords)
 	}
-	for _, event := range records {
+	for _, event := range messages {
 		if event.Role == session.MessageRoleUser {
 			t.Fatalf("materialized transcript contains user message: %+v", event)
 		}
@@ -426,7 +426,7 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
 	}
-	records := f.collectMessageRecords(t, record.SessionDir)
+	_, records := f.collectMessageRecords(t, record.SessionDir)
 	goalNotices, userMessages := 0, 0
 	for _, event := range records {
 		message := event
@@ -442,7 +442,7 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 	}
 }
 
-func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string) []session.MessageRecord {
+func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string) ([]session.EventRecord, []session.MessageRecord) {
 	store, err := session.Open(sessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("open materialized Session: %v", err)
@@ -462,7 +462,7 @@ func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string)
 			messages = append(messages, message)
 		}
 	}
-	return messages
+	return records, messages
 }
 
 func (f *lazyGoalFixture) requireOneSession(t *testing.T) {

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -49,6 +49,22 @@ type lazyGoalFailingClient struct {
 	release      chan struct{}
 }
 
+type lazyGoalLaunchClient interface {
+	PlanSession(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error)
+	MaterializeWorkspaceChat(context.Context, serverapi.WorkspaceChatMaterializeRequest) (serverapi.WorkspaceChatMaterializeResponse, error)
+}
+
+type lazyGoalFixture struct {
+	appCore      *Core
+	binding      metadata.Binding
+	launch       lazyGoalLaunchClient
+	draft        metadata.WorkspaceChatDraftDocument
+	materialized serverapi.WorkspaceChatMaterializeResponse
+	planned      serverapi.SessionPlanResponse
+	activation   serverapi.SessionRuntimeActivateResponse
+	released     bool
+}
+
 func (c *lazyGoalFailingClient) Generate(ctx context.Context, _ llm.Request) (llm.Response, error) {
 	c.mu.Lock()
 	c.calls++
@@ -69,7 +85,9 @@ func (*lazyGoalFailingClient) ProviderCapabilities(context.Context) (llm.Provide
 
 func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	blocking := &lazyGoalBlockingClient{started: make(chan struct{})}
-	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, blocking)
+	fixture := newLazyGoalFixture(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, blocking)
+	appCore := fixture.appCore
+	binding := fixture.binding
 	goalClient := appCore.RuntimeControlClient()
 
 	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
@@ -84,50 +102,8 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 		t.Fatalf("untouched lazy Chat exposed Sessions: %+v", page.Sessions)
 	}
 
-	draft := writeLazyGoalDraft(t, appCore, binding)
-	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
-	if err != nil {
-		t.Fatalf("MaterializeWorkspaceChat: %v", err)
-	}
-
-	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
-		ClientRequestID: "lazy-goal-plan",
-		Mode:            serverapi.SessionLaunchModeInteractive,
-		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
-	})
-	if err != nil {
-		t.Fatalf("PlanSession: %v", err)
-	}
-	if planned.Plan.SessionID != materialized.SessionID.String() {
-		t.Fatalf("planned Session = %q, want %q", planned.Plan.SessionID, materialized.SessionID)
-	}
-	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
-		ClientRequestID:          "lazy-goal-activate",
-		SessionID:                materialized.SessionID.String(),
-		OwnerID:                  "lazy-goal-owner",
-		ActiveSettings:           planned.Plan.ActiveSettings,
-		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
-		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
-		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
-		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
-		Source:                   planned.Plan.Source,
-	})
-	if err != nil {
-		t.Fatalf("ActivateSessionRuntime: %v", err)
-	}
-	released := false
-	t.Cleanup(func() {
-		if released {
-			return
-		}
-		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-			ClientRequestID: "lazy-goal-release",
-			Attachment:      activation.Attachment,
-			OwnerID:         "lazy-goal-owner",
-			DropOwner:       true,
-		})
-	})
-
+	fixture.materializeAndActivate(t, "lazy-goal")
+	materialized := fixture.materialized
 	response, err := goalClient.SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "lazy-goal-set",
 		SessionID:       materialized.SessionID.String(),
@@ -154,47 +130,19 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ChatDraftStateFromMeta: %v", err)
 	}
-	if state.Message != draft.Message || state.Agent != draft.Agent ||
+	if state.Message != fixture.draft.Message || state.Agent != fixture.draft.Agent ||
 		state.Settings == nil ||
-		*state.Settings.Supervisor != draft.Supervisor ||
-		*state.Settings.Thinking != draft.Thinking ||
-		*state.Settings.Fast != draft.Fast ||
-		*state.Settings.Questions != draft.Questions ||
-		*state.Settings.AutoCompaction != draft.AutoCompaction {
-		t.Fatalf("materialized Chat state = %+v, want %+v", state, draft)
+		*state.Settings.Supervisor != fixture.draft.Supervisor ||
+		*state.Settings.Thinking != fixture.draft.Thinking ||
+		*state.Settings.Fast != fixture.draft.Fast ||
+		*state.Settings.Questions != fixture.draft.Questions ||
+		*state.Settings.AutoCompaction != fixture.draft.AutoCompaction {
+		t.Fatalf("materialized Chat state = %+v, want %+v", state, fixture.draft)
 	}
 	if record.Meta.Goal == nil || record.Meta.Goal.Objective != response.Goal.Objective || record.Meta.Goal.Status != session.GoalStatusActive {
 		t.Fatalf("persisted Goal = %+v, want active Goal", record.Meta.Goal)
 	}
-	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
-	goalNotices := 0
-	userMessages := 0
-	for _, event := range records {
-		payload, payloadErr := event.Payload()
-		if payloadErr != nil {
-			t.Fatalf("event payload: %v", payloadErr)
-		}
-		message, ok := payload.(session.MessageRecord)
-		if !ok {
-			continue
-		}
-		if message.MessageType != nil && *message.MessageType == session.MessageTypeGoal {
-			goalNotices++
-		}
-		if message.Role == session.MessageRoleUser {
-			userMessages++
-		}
-	}
-	if goalNotices != 1 || userMessages != 0 {
-		t.Fatalf("materialized Goal records = notices:%d user_messages:%d, want one notice and no user message", goalNotices, userMessages)
-	}
+	fixture.requireGoalNoticeWithoutUserMessage(t)
 	page, err = appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
 		ProjectID: binding.ProjectID,
 		Category:  sessioncontract.SessionCategoryMain,
@@ -206,69 +154,20 @@ func TestCoreLazyChatMaterializesBeforeGoalSet(t *testing.T) {
 	if len(page.Sessions) != 1 {
 		t.Fatalf("materialized Session list = %+v, want one", page.Sessions)
 	}
-	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-		ClientRequestID: "lazy-goal-release-explicit",
-		Attachment:      activation.Attachment,
-		OwnerID:         "lazy-goal-owner",
-		DropOwner:       true,
-	})
-	if err != nil {
-		t.Fatalf("ReleaseSessionRuntime: %v", err)
-	}
-	if !releaseResponse.Released || releaseResponse.Active {
-		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
-	}
-	released = true
+	fixture.release(t, "lazy-goal")
 }
 
 func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *testing.T) {
 	client := &lazyGoalBlockingClient{started: make(chan struct{})}
-	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolExecCommand: true}, client)
-	draft := writeLazyGoalDraft(t, appCore, binding)
+	fixture := newLazyGoalFixture(t, map[toolspec.ID]bool{toolspec.ToolExecCommand: true}, client)
+	fixture.materializeAndActivate(t, "lazy-capability")
+	materialized := fixture.materialized
+	appCore := fixture.appCore
+	if containsTool(fixture.planned.Plan.EnabledToolIDs, string(toolspec.ToolAskQuestion)) {
+		t.Fatalf("planned materialized tool contract unexpectedly enables ask_question: %v", fixture.planned.Plan.EnabledToolIDs)
+	}
 
-	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
-	if err != nil {
-		t.Fatalf("MaterializeWorkspaceChat: %v", err)
-	}
-	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
-		ClientRequestID: "lazy-capability-plan",
-		Mode:            serverapi.SessionLaunchModeInteractive,
-		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
-	})
-	if err != nil {
-		t.Fatalf("PlanSession: %v", err)
-	}
-	if containsTool(planned.Plan.EnabledToolIDs, string(toolspec.ToolAskQuestion)) {
-		t.Fatalf("planned materialized tool contract unexpectedly enables ask_question: %v", planned.Plan.EnabledToolIDs)
-	}
-	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
-		ClientRequestID:          "lazy-capability-activate",
-		SessionID:                materialized.SessionID.String(),
-		OwnerID:                  "lazy-capability-owner",
-		ActiveSettings:           planned.Plan.ActiveSettings,
-		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
-		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
-		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
-		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
-		Source:                   planned.Plan.Source,
-	})
-	if err != nil {
-		t.Fatalf("ActivateSessionRuntime: %v", err)
-	}
-	released := false
-	t.Cleanup(func() {
-		if released {
-			return
-		}
-		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-			ClientRequestID: "lazy-capability-release",
-			Attachment:      activation.Attachment,
-			OwnerID:         "lazy-capability-owner",
-			DropOwner:       true,
-		})
-	})
-
-	_, err = appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
+	_, err := appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "lazy-capability-set",
 		SessionID:       materialized.SessionID.String(),
 		Objective:       "this must be rejected",
@@ -284,57 +183,16 @@ func TestCoreLazyChatGoalRejectsUnavailableCapabilityAfterMaterialization(t *tes
 	if record.Meta.Goal != nil {
 		t.Fatalf("rejected capability Goal persisted: %+v", record.Meta.Goal)
 	}
-	state, err := session.ChatDraftStateFromMeta(*record.Meta)
-	if err != nil {
-		t.Fatalf("ChatDraftStateFromMeta: %v", err)
-	}
-	if state.Message != draft.Message {
-		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
-	}
-	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
-	if len(records) != 0 {
-		t.Fatalf("rejected capability created transcript records: %+v", records)
-	}
-	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
-		ProjectID: binding.ProjectID,
-		Category:  sessioncontract.SessionCategoryMain,
-		Limit:     intPointer(20),
-	})
-	if err != nil {
-		t.Fatalf("ListSessionPage: %v", err)
-	}
-	if len(page.Sessions) != 1 {
-		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
-	}
-	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-		ClientRequestID: "lazy-capability-release-explicit",
-		Attachment:      activation.Attachment,
-		OwnerID:         "lazy-capability-owner",
-		DropOwner:       true,
-	})
-	if err != nil {
-		t.Fatalf("ReleaseSessionRuntime: %v", err)
-	}
-	if !releaseResponse.Released || releaseResponse.Active {
-		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
-	}
-	released = true
+	fixture.requireNoTranscript(t)
+	fixture.requireOneSession(t)
+	fixture.release(t, "lazy-capability")
 }
 
 func TestCoreLazyChatGoalAdmissionRejectionRetainsMaterializedSession(t *testing.T) {
-	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, &lazyGoalBlockingClient{started: make(chan struct{})})
-	draft := writeLazyGoalDraft(t, appCore, binding)
-	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
-	if err != nil {
-		t.Fatalf("MaterializeWorkspaceChat: %v", err)
-	}
+	fixture := newLazyGoalFixture(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, &lazyGoalBlockingClient{started: make(chan struct{})})
+	fixture.materialize(t)
+	appCore := fixture.appCore
+	materialized := fixture.materialized
 	releaseBlock, err := appCore.safeBundles().Runtime.runtimeAuthority.BlockSessionStarts(
 		t.Context(),
 		[]runtimeids.SessionID{materialized.SessionID},
@@ -361,35 +219,8 @@ func TestCoreLazyChatGoalAdmissionRejectionRetainsMaterializedSession(t *testing
 	if record.Meta.Goal != nil {
 		t.Fatalf("admission-rejected Goal persisted: %+v", record.Meta.Goal)
 	}
-	state, err := session.ChatDraftStateFromMeta(*record.Meta)
-	if err != nil {
-		t.Fatalf("ChatDraftStateFromMeta: %v", err)
-	}
-	if state.Message != draft.Message {
-		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
-	}
-	store, err := session.Open(record.SessionDir, appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
-	if err != nil {
-		t.Fatalf("open materialized Session: %v", err)
-	}
-	records, err := sessiontest.CollectRecords(store)
-	if err != nil {
-		t.Fatalf("CollectRecords: %v", err)
-	}
-	if len(records) != 0 {
-		t.Fatalf("admission rejection created transcript records: %+v", records)
-	}
-	page, err := appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
-		ProjectID: binding.ProjectID,
-		Category:  sessioncontract.SessionCategoryMain,
-		Limit:     intPointer(20),
-	})
-	if err != nil {
-		t.Fatalf("ListSessionPage: %v", err)
-	}
-	if len(page.Sessions) != 1 {
-		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
-	}
+	fixture.requireNoTranscript(t)
+	fixture.requireOneSession(t)
 }
 
 func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
@@ -398,34 +229,10 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 		returned: make(chan struct{}),
 		release:  make(chan struct{}),
 	}
-	appCore, binding, launchClient := newLazyGoalCore(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, client)
-	draft := writeLazyGoalDraft(t, appCore, binding)
-	materialized, err := launchClient.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
-	if err != nil {
-		t.Fatalf("MaterializeWorkspaceChat: %v", err)
-	}
-	planned, err := launchClient.PlanSession(t.Context(), serverapi.SessionPlanRequest{
-		ClientRequestID: "lazy-failure-plan",
-		Mode:            serverapi.SessionLaunchModeInteractive,
-		Intent:          serverapi.OpenExistingSessionLaunchIntent(materialized.SessionID),
-	})
-	if err != nil {
-		t.Fatalf("PlanSession: %v", err)
-	}
-	activation, err := appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
-		ClientRequestID:          "lazy-failure-activate",
-		SessionID:                materialized.SessionID.String(),
-		OwnerID:                  "lazy-failure-owner",
-		ActiveSettings:           planned.Plan.ActiveSettings,
-		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
-		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
-		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
-		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
-		Source:                   planned.Plan.Source,
-	})
-	if err != nil {
-		t.Fatalf("ActivateSessionRuntime: %v", err)
-	}
+	fixture := newLazyGoalFixture(t, map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}, client)
+	fixture.materializeAndActivate(t, "lazy-failure")
+	appCore := fixture.appCore
+	materialized := fixture.materialized
 	response, err := appCore.RuntimeControlClient().SetGoal(t.Context(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "lazy-failure-set",
 		SessionID:       materialized.SessionID.String(),
@@ -449,31 +256,22 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for provider failure return")
 	}
-	deadline := time.Now().Add(3 * time.Second)
+	settleCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
 	for {
-		view, viewErr := appCore.SessionViewClient().GetSessionMainView(t.Context(), serverapi.SessionMainViewRequest{
+		view, viewErr := appCore.SessionViewClient().GetSessionMainView(settleCtx, serverapi.SessionMainViewRequest{
 			SessionID: materialized.SessionID.String(),
 		})
 		if viewErr == nil && view.MainView.Activity.State == clientui.RuntimeActivityRegisteredIdle {
 			break
 		}
-		if time.Now().After(deadline) {
+		select {
+		case <-settleCtx.Done():
 			t.Fatalf("runtime did not settle idle after provider failure: view error=%v", viewErr)
+		case <-time.After(10 * time.Millisecond):
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
-	releaseResponse, err := appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-		ClientRequestID: "lazy-failure-release",
-		Attachment:      activation.Attachment,
-		OwnerID:         "lazy-failure-owner",
-		DropOwner:       true,
-	})
-	if err != nil {
-		t.Fatalf("ReleaseSessionRuntime: %v", err)
-	}
-	if !releaseResponse.Released || releaseResponse.Active {
-		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", releaseResponse)
-	}
+	fixture.release(t, "lazy-failure")
 	client.mu.Lock()
 	calls := client.calls
 	client.mu.Unlock()
@@ -487,13 +285,7 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 	if record.Meta.Goal == nil || record.Meta.Goal.ID != response.Goal.ID || record.Meta.Goal.Status != session.GoalStatusActive {
 		t.Fatalf("durable Goal = %+v, want accepted active Goal", record.Meta.Goal)
 	}
-	state, err := session.ChatDraftStateFromMeta(*record.Meta)
-	if err != nil {
-		t.Fatalf("ChatDraftStateFromMeta: %v", err)
-	}
-	if state.Message != draft.Message {
-		t.Fatalf("composer draft = %q, want %q", state.Message, draft.Message)
-	}
+	fixture.requireDraftAndTranscript(t, nil)
 }
 
 func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) (*Core, metadata.Binding, interface {
@@ -516,7 +308,7 @@ func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm
 	if err != nil {
 		t.Fatalf("RegisterBinding: %v", err)
 	}
-	appCore := newCoreTestAppWithRuntimeFactory(t, resolved.Config, auth.EmptyState(), runtimewire.RuntimeClientFactoryFunc(
+	appCore := newCoreTestApp(t, resolved.Config, auth.EmptyState(), runtimewire.RuntimeClientFactoryFunc(
 		func(context.Context, runtimewire.RuntimeClientRequest) (llm.Client, error) {
 			return client, nil
 		},
@@ -526,6 +318,177 @@ func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm
 		t.Fatalf("SessionLaunchClientForProjectWorkspace: %v", err)
 	}
 	return appCore, binding, launchClient
+}
+
+func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) *lazyGoalFixture {
+	t.Helper()
+	appCore, binding, launch := newLazyGoalCore(t, enabledTools, client)
+	fixture := &lazyGoalFixture{
+		appCore: appCore,
+		binding: binding,
+		launch:  launch,
+		draft:   writeLazyGoalDraft(t, appCore, binding),
+	}
+	t.Cleanup(func() {
+		if fixture.released || fixture.activation.Attachment.SessionID == "" {
+			return
+		}
+		_, _ = appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+			ClientRequestID: "lazy-goal-release-cleanup",
+			Attachment:      fixture.activation.Attachment,
+			OwnerID:         "lazy-goal-cleanup",
+			DropOwner:       true,
+		})
+	})
+	return fixture
+}
+
+func (f *lazyGoalFixture) materialize(t *testing.T) {
+	t.Helper()
+	materialized, err := f.launch.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+	f.materialized = materialized
+}
+
+func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
+	t.Helper()
+	f.materialize(t)
+	planned, err := f.launch.PlanSession(t.Context(), serverapi.SessionPlanRequest{
+		ClientRequestID: prefix + "-plan",
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		Intent:          serverapi.OpenExistingSessionLaunchIntent(f.materialized.SessionID),
+	})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	f.planned = planned
+	activation, err := f.appCore.SessionRuntimeClient().ActivateSessionRuntime(t.Context(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID:          prefix + "-activate",
+		SessionID:                f.materialized.SessionID.String(),
+		OwnerID:                  prefix + "-owner",
+		ActiveSettings:           planned.Plan.ActiveSettings,
+		EnabledToolIDs:           planned.Plan.EnabledToolIDs,
+		QuestionsEnabled:         boolPointer(planned.Plan.QuestionsEnabled),
+		AutoCompactionEnabled:    boolPointer(planned.Plan.AutoCompactionEnabled),
+		ThinkingOverrideExplicit: planned.Plan.ThinkingOverrideExplicit,
+		Source:                   planned.Plan.Source,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	f.activation = activation
+}
+
+func (f *lazyGoalFixture) release(t *testing.T, ownerID string) {
+	t.Helper()
+	response, err := f.appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "lazy-goal-release",
+		Attachment:      f.activation.Attachment,
+		OwnerID:         ownerID,
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if !response.Released || response.Active {
+		t.Fatalf("ReleaseSessionRuntime response = %+v, want released inactive", response)
+	}
+	f.released = true
+}
+
+func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *int) {
+	t.Helper()
+	record, err := f.appCore.MetadataStore().ResolvePersistedSession(t.Context(), f.materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	state, err := session.ChatDraftStateFromMeta(*record.Meta)
+	if err != nil {
+		t.Fatalf("ChatDraftStateFromMeta: %v", err)
+	}
+	if state.Message != f.draft.Message {
+		t.Fatalf("composer draft = %q, want %q", state.Message, f.draft.Message)
+	}
+	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	if wantRecords != nil && len(records) != *wantRecords {
+		t.Fatalf("materialized transcript records = %d, want %d", len(records), *wantRecords)
+	}
+	for _, event := range records {
+		payload, payloadErr := event.Payload()
+		if payloadErr != nil {
+			t.Fatalf("event payload: %v", payloadErr)
+		}
+		message, ok := payload.(session.MessageRecord)
+		if ok && message.Role == session.MessageRoleUser {
+			t.Fatalf("materialized transcript contains user message: %+v", message)
+		}
+	}
+}
+
+func (f *lazyGoalFixture) requireNoTranscript(t *testing.T) {
+	t.Helper()
+	wantRecords := 0
+	f.requireDraftAndTranscript(t, &wantRecords)
+}
+
+func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
+	t.Helper()
+	record, err := f.appCore.MetadataStore().ResolvePersistedSession(t.Context(), f.materialized.SessionID.String())
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession: %v", err)
+	}
+	store, err := session.Open(record.SessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("open materialized Session: %v", err)
+	}
+	records, err := sessiontest.CollectRecords(store)
+	if err != nil {
+		t.Fatalf("CollectRecords: %v", err)
+	}
+	goalNotices, userMessages := 0, 0
+	for _, event := range records {
+		payload, payloadErr := event.Payload()
+		if payloadErr != nil {
+			t.Fatalf("event payload: %v", payloadErr)
+		}
+		message, ok := payload.(session.MessageRecord)
+		if !ok {
+			continue
+		}
+		if message.MessageType != nil && *message.MessageType == session.MessageTypeGoal {
+			goalNotices++
+		}
+		if message.Role == session.MessageRoleUser {
+			userMessages++
+		}
+	}
+	if goalNotices != 1 || userMessages != 0 {
+		t.Fatalf("materialized Goal records = notices:%d user_messages:%d, want one notice and no user message", goalNotices, userMessages)
+	}
+}
+
+func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
+	t.Helper()
+	page, err := f.appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		ProjectID: f.binding.ProjectID,
+		Category:  sessioncontract.SessionCategoryMain,
+		Limit:     intPointer(20),
+	})
+	if err != nil {
+		t.Fatalf("ListSessionPage: %v", err)
+	}
+	if len(page.Sessions) != 1 {
+		t.Fatalf("retained Session list = %+v, want one", page.Sessions)
+	}
 }
 
 func writeLazyGoalDraft(t *testing.T, appCore *Core, binding metadata.Binding) metadata.WorkspaceChatDraftDocument {
@@ -554,29 +517,10 @@ func containsTool(tools []string, want string) bool {
 	return false
 }
 
-func intPointer(value int) *int {
-	return &value
-}
-
 func boolPointer(value bool) *bool {
 	return &value
 }
 
-func newCoreTestAppWithRuntimeFactory(t *testing.T, cfg brand.App, state auth.State, factory runtimewire.RuntimeClientFactory) *Core {
-	t.Helper()
-	authSupport, err := serverbootstrap.BuildAuthSupport(auth.NewMemoryStore(state), nil, nil)
-	if err != nil {
-		t.Fatalf("BuildAuthSupport: %v", err)
-	}
-	runtimeSupport, err := serverbootstrap.BuildRuntimeSupport(cfg)
-	if err != nil {
-		t.Fatalf("BuildRuntimeSupport: %v", err)
-	}
-	t.Cleanup(func() { _ = runtimeSupport.Background.Close() })
-	appCore, err := NewWithContextOptions(t.Context(), cfg, authSupport, runtimeSupport, Options{RuntimeClientFactory: factory})
-	if err != nil {
-		t.Fatalf("NewWithContextOptions: %v", err)
-	}
-	t.Cleanup(func() { _ = appCore.Close() })
-	return appCore
+func intPointer(value int) *int {
+	return &value
 }

--- a/server/core/lazy_chat_goal_test.go
+++ b/server/core/lazy_chat_goal_test.go
@@ -291,7 +291,6 @@ func TestCoreLazyChatGoalProviderFailurePreservesAcceptedGoal(t *testing.T) {
 }
 
 func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) (*Core, metadata.Binding, lazyGoalLaunchClient) {
-	t.Helper()
 	workspace := t.TempDir()
 	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{
 		WorkspaceRoot: workspace,
@@ -320,7 +319,6 @@ func newLazyGoalCore(t *testing.T, enabledTools map[toolspec.ID]bool, client llm
 }
 
 func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client llm.Client) *lazyGoalFixture {
-	t.Helper()
 	appCore, binding, launch := newLazyGoalCore(t, enabledTools, client)
 	fixture := &lazyGoalFixture{
 		appCore: appCore,
@@ -343,7 +341,6 @@ func newLazyGoalFixture(t *testing.T, enabledTools map[toolspec.ID]bool, client 
 }
 
 func (f *lazyGoalFixture) materialize(t *testing.T) {
-	t.Helper()
 	materialized, err := f.launch.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
 	if err != nil {
 		t.Fatalf("MaterializeWorkspaceChat: %v", err)
@@ -352,7 +349,6 @@ func (f *lazyGoalFixture) materialize(t *testing.T) {
 }
 
 func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
-	t.Helper()
 	f.materialize(t)
 	planned, err := f.launch.PlanSession(t.Context(), serverapi.SessionPlanRequest{
 		ClientRequestID: prefix + "-plan",
@@ -382,7 +378,6 @@ func (f *lazyGoalFixture) materializeAndActivate(t *testing.T, prefix string) {
 }
 
 func (f *lazyGoalFixture) release(t *testing.T) {
-	t.Helper()
 	response, err := f.appCore.SessionRuntimeClient().ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
 		ClientRequestID: "lazy-goal-release",
 		Attachment:      f.activation.Attachment,
@@ -399,7 +394,6 @@ func (f *lazyGoalFixture) release(t *testing.T) {
 }
 
 func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *int) {
-	t.Helper()
 	record, err := f.appCore.MetadataStore().ResolvePersistedSession(t.Context(), f.materialized.SessionID.String())
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
@@ -423,13 +417,11 @@ func (f *lazyGoalFixture) requireDraftAndTranscript(t *testing.T, wantRecords *i
 }
 
 func (f *lazyGoalFixture) requireNoTranscript(t *testing.T) {
-	t.Helper()
 	wantRecords := 0
 	f.requireDraftAndTranscript(t, &wantRecords)
 }
 
 func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
-	t.Helper()
 	record, err := f.appCore.MetadataStore().ResolvePersistedSession(t.Context(), f.materialized.SessionID.String())
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
@@ -451,7 +443,6 @@ func (f *lazyGoalFixture) requireGoalNoticeWithoutUserMessage(t *testing.T) {
 }
 
 func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string) []session.MessageRecord {
-	t.Helper()
 	store, err := session.Open(sessionDir, f.appCore.MetadataStore().AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("open materialized Session: %v", err)
@@ -475,7 +466,6 @@ func (f *lazyGoalFixture) collectMessageRecords(t *testing.T, sessionDir string)
 }
 
 func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
-	t.Helper()
 	page, err := f.appCore.ProjectViewClient().ListSessionPage(t.Context(), serverapi.SessionPageRequest{
 		ProjectID: f.binding.ProjectID,
 		Category:  sessioncontract.SessionCategoryMain,
@@ -490,7 +480,6 @@ func (f *lazyGoalFixture) requireOneSession(t *testing.T) {
 }
 
 func writeLazyGoalDraft(t *testing.T, appCore *Core, binding metadata.Binding) metadata.WorkspaceChatDraftDocument {
-	t.Helper()
 	draft := metadata.WorkspaceChatDraftDocument{
 		Message:        "unsent composer draft",
 		Agent:          brand.DefaultSubagentRole,

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -2571,21 +2571,9 @@ func countDirectShellCommandMessages(t *testing.T, store *session.Store, command
 
 func runtimeControlMessageRecords(t *testing.T, store *session.Store) []session.MessageRecord {
 	t.Helper()
-	records, err := sessiontest.CollectRecords(store)
+	_, messages, err := sessiontest.CollectRecordsAndMessages(store)
 	if err != nil {
-		t.Fatalf("collect event records: %v", err)
-	}
-	messages := make([]session.MessageRecord, 0)
-	for _, record := range records {
-		payload, payloadErr := record.Payload()
-		if payloadErr != nil {
-			t.Fatalf("read event record payload: %v", payloadErr)
-		}
-		message, ok := payload.(session.MessageRecord)
-		if !ok {
-			continue
-		}
-		messages = append(messages, message)
+		t.Fatalf("collect message records: %v", err)
 	}
 	return messages
 }

--- a/server/session/sessiontest/sessiontest.go
+++ b/server/session/sessiontest/sessiontest.go
@@ -159,6 +159,33 @@ func CollectRecords(store *session.Store) ([]session.EventRecord, error) {
 	return records, nil
 }
 
+func CollectRecordsAndMessages(store *session.Store) ([]session.EventRecord, []session.MessageRecord, error) {
+	records, err := CollectRecords(store)
+	if err != nil {
+		return nil, nil, err
+	}
+	messages, err := MessageRecords(records)
+	if err != nil {
+		return nil, nil, err
+	}
+	return records, messages, nil
+}
+
+func MessageRecords(records []session.EventRecord) ([]session.MessageRecord, error) {
+	messages := make([]session.MessageRecord, 0, len(records))
+	for _, record := range records {
+		payload, err := record.Payload()
+		if err != nil {
+			return nil, err
+		}
+		message, ok := payload.(session.MessageRecord)
+		if ok {
+			messages = append(messages, message)
+		}
+	}
+	return messages, nil
+}
+
 // AgentRole constructs a present continuation agent-role fixture. Test-only.
 func AgentRole(value string) *string {
 	return &value

--- a/shared/client/lazy_chat_goal_reconnect_test.go
+++ b/shared/client/lazy_chat_goal_reconnect_test.go
@@ -1,0 +1,244 @@
+package client
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"core/server/auth"
+	serverbootstrap "core/server/bootstrap"
+	"core/server/core"
+	"core/server/metadata"
+	servertransport "core/server/transport"
+	"core/shared/config"
+	"core/shared/protocol"
+	"core/shared/rpcwire"
+	"core/shared/serverapi"
+	"core/shared/sessioncontract"
+)
+
+func reconnectIntPointer(value int) *int {
+	return &value
+}
+
+type reconnectCountingTransport struct {
+	base             rpcwire.WebSocketTransport
+	materializations atomic.Int32
+	goalSets         atomic.Int32
+	first            *reconnectCountingConn
+	firstOnce        sync.Once
+}
+
+func (t *reconnectCountingTransport) Dial(ctx context.Context, endpoint rpcwire.Endpoint) (rpcwire.Conn, error) {
+	conn, err := t.base.Dial(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := newReconnectCountingConn(conn, &t.materializations, &t.goalSets)
+	t.firstOnce.Do(func() {
+		t.first = wrapped
+	})
+	return wrapped, nil
+}
+
+type reconnectCountingConn struct {
+	inner        rpcwire.Conn
+	materializes *atomic.Int32
+	goalSets     *atomic.Int32
+	closed       chan struct{}
+	closedOnce   sync.Once
+}
+
+func newReconnectCountingConn(inner rpcwire.Conn, materializations, goalSets *atomic.Int32) *reconnectCountingConn {
+	conn := &reconnectCountingConn{
+		inner:        inner,
+		materializes: materializations,
+		goalSets:     goalSets,
+		closed:       make(chan struct{}),
+	}
+	go func() {
+		<-inner.Closed()
+		conn.closedOnce.Do(func() { close(conn.closed) })
+	}()
+	return conn
+}
+
+func (c *reconnectCountingConn) Send(ctx context.Context, frame rpcwire.Frame) error {
+	switch frame.Method {
+	case protocol.MethodSessionWorkspaceChatMaterialize:
+		c.materializes.Add(1)
+	case protocol.MethodRuntimeGoalSet:
+		c.goalSets.Add(1)
+	}
+	return c.inner.Send(ctx, frame)
+}
+
+func (c *reconnectCountingConn) Events() <-chan rpcwire.Event {
+	return c.inner.Events()
+}
+
+func (c *reconnectCountingConn) Closed() <-chan struct{} {
+	return c.closed
+}
+
+func (c *reconnectCountingConn) Close() error {
+	return c.inner.Close()
+}
+
+func (c *reconnectCountingConn) Drop() error {
+	return c.inner.Close()
+}
+
+func TestRemoteLazyChatMaterializationReconnectDoesNotReplayGoal(t *testing.T) {
+	appCore, server := newLazyChatReconnectServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+
+	endpoint, err := rpcwire.ParseWebSocketEndpoint("ws" + server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("ParseWebSocketEndpoint: %v", err)
+	}
+	intent, err := newRemoteDefaultProjectAttachmentIntent(appCore.ProjectID())
+	if err != nil {
+		t.Fatalf("newRemoteDefaultProjectAttachmentIntent: %v", err)
+	}
+	transport := &reconnectCountingTransport{base: rpcwire.NewWebSocketTransport()}
+	remote, err := dialRemoteWithTransport(
+		t.Context(),
+		remoteDialPlan{endpoints: []rpcwire.Endpoint{endpoint}},
+		transport,
+		intent,
+	)
+	if err != nil {
+		t.Fatalf("dialRemoteWithTransport: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+
+	draft := "reconnect-safe unsent composer draft"
+	launch, err := remote.WorkspaceChatDraft(t.Context(), serverapi.WorkspaceChatDraftRequest{
+		Operation: serverapi.WorkspaceChatDraftOperation{
+			Kind:    serverapi.WorkspaceChatDraftUpdateMessage,
+			Message: &draft,
+		},
+	})
+	if err != nil {
+		t.Fatalf("WorkspaceChatDraft update: %v", err)
+	}
+	if launch.Message != draft {
+		t.Fatalf("workspace draft = %q, want %q", launch.Message, draft)
+	}
+	materialized, err := remote.MaterializeWorkspaceChat(t.Context(), serverapi.WorkspaceChatMaterializeRequest{})
+	if err != nil {
+		t.Fatalf("MaterializeWorkspaceChat: %v", err)
+	}
+	if materialized.SessionID.IsZero() || !materialized.SessionID.IsCanonicalUUIDv4() {
+		t.Fatalf("materialized Session identity = %q, want canonical UUIDv4", materialized.SessionID)
+	}
+	first := transport.first
+	if first == nil {
+		t.Fatal("materialization did not use the first physical connection")
+	}
+	if err := first.Drop(); err != nil {
+		t.Fatalf("DropFirstConnection: %v", err)
+	}
+	select {
+	case <-first.Closed():
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first physical connection closure")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	var page serverapi.SessionPageResponse
+	for {
+		page, err = remote.ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+			ProjectID: appCore.ProjectID(),
+			Category:  sessioncontract.SessionCategoryMain,
+			Limit:     reconnectIntPointer(20),
+		})
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Session list did not reconnect: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(page.Sessions) != 1 || page.Sessions[0].SessionID != materialized.SessionID {
+		t.Fatalf("reconnected Session page = %+v, want exactly %q", page.Sessions, materialized.SessionID)
+	}
+	input, err := remote.GetInitialInput(t.Context(), serverapi.SessionInitialInputRequest{
+		SessionID: materialized.SessionID.String(),
+	})
+	if err != nil {
+		t.Fatalf("GetInitialInput after reconnect: %v", err)
+	}
+	if input.Input != draft {
+		t.Fatalf("reconnected composer draft = %q, want %q", input.Input, draft)
+	}
+	goal, err := remote.ShowGoal(t.Context(), serverapi.RuntimeGoalShowRequest{
+		SessionID: materialized.SessionID.String(),
+	})
+	if err != nil {
+		t.Fatalf("ShowGoal after reconnect: %v", err)
+	}
+	if goal.Goal != nil {
+		t.Fatalf("reconnected Goal = %+v, want nil", goal.Goal)
+	}
+	if got := transport.materializations.Load(); got != 1 {
+		t.Fatalf("materialization requests = %d, want one", got)
+	}
+	if got := transport.goalSets.Load(); got != 0 {
+		t.Fatalf("Goal Set requests = %d, want zero", got)
+	}
+}
+
+func newLazyChatReconnectServer(t *testing.T) (*core.Core, *httptest.Server) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workspace := t.TempDir()
+	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{
+		WorkspaceRoot: workspace,
+		LoadOptions:   config.LoadOptions{ConfigRoot: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	binding, err := metadata.RegisterBinding(t.Context(), resolved.Config.PersistenceRoot, workspace)
+	if err != nil {
+		t.Fatalf("RegisterBinding: %v", err)
+	}
+	authSupport, err := serverbootstrap.BuildAuthSupport(auth.NewMemoryStore(auth.EmptyState()), nil, nil)
+	if err != nil {
+		t.Fatalf("BuildAuthSupport: %v", err)
+	}
+	if _, err := authSupport.AuthManager.SwitchMethod(t.Context(), auth.Method{
+		Type:   auth.MethodAPIKey,
+		APIKey: &auth.APIKeyMethod{Key: "reconnect-test-key"},
+	}, true); err != nil {
+		t.Fatalf("SwitchMethod: %v", err)
+	}
+	runtimeSupport, err := serverbootstrap.BuildRuntimeSupport(resolved.Config)
+	if err != nil {
+		t.Fatalf("BuildRuntimeSupport: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeSupport.Background.Close() })
+	appCore, err := core.New(resolved.Config, authSupport, runtimeSupport)
+	if err != nil {
+		t.Fatalf("core.New: %v", err)
+	}
+	if appCore.ProjectID() != binding.ProjectID {
+		t.Fatalf("Core ProjectID = %q, want %q", appCore.ProjectID(), binding.ProjectID)
+	}
+	gateway, err := servertransport.NewGateway(appCore, protocol.ServerIdentity{
+		ProtocolVersion: protocol.Version,
+		ServerID:        "lazy-chat-reconnect-test",
+	})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	return appCore, httptest.NewServer(gateway.Handler())
+}

--- a/shared/client/lazy_chat_goal_reconnect_test.go
+++ b/shared/client/lazy_chat_goal_reconnect_test.go
@@ -131,11 +131,7 @@ func TestRemoteLazyChatMaterializationReconnectDoesNotReplayGoal(t *testing.T) {
 	if err := first.Close(); err != nil {
 		t.Fatalf("DropFirstConnection: %v", err)
 	}
-	select {
-	case <-first.Closed():
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for first physical connection closure")
-	}
+	waitForRemoteControlDisconnect(t, remote, nil)
 
 	pollCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	defer cancel()

--- a/shared/client/lazy_chat_goal_reconnect_test.go
+++ b/shared/client/lazy_chat_goal_reconnect_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
@@ -19,10 +21,6 @@ import (
 	"core/shared/serverapi"
 	"core/shared/sessioncontract"
 )
-
-func reconnectIntPointer(value int) *int {
-	return &value
-}
 
 type reconnectCountingTransport struct {
 	base             rpcwire.WebSocketTransport
@@ -150,21 +148,29 @@ func TestRemoteLazyChatMaterializationReconnectDoesNotReplayGoal(t *testing.T) {
 		t.Fatal("timed out waiting for first physical connection closure")
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	pollCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
 	var page serverapi.SessionPageResponse
 	for {
-		page, err = remote.ListSessionPage(t.Context(), serverapi.SessionPageRequest{
+		page, err = remote.ListSessionPage(pollCtx, serverapi.SessionPageRequest{
 			ProjectID: appCore.ProjectID(),
 			Category:  sessioncontract.SessionCategoryMain,
-			Limit:     reconnectIntPointer(20),
+			Limit:     remoteTestIntPointer(20),
 		})
 		if err == nil {
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("Session list did not reconnect: %v", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Session list did not reconnect before deadline: %v", err)
 		}
-		time.Sleep(10 * time.Millisecond)
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Session list reconnect failed with non-transient error: %v", err)
+		}
+		select {
+		case <-pollCtx.Done():
+			t.Fatalf("Session list did not reconnect: %v", pollCtx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 	if len(page.Sessions) != 1 || page.Sessions[0].SessionID != materialized.SessionID {
 		t.Fatalf("reconnected Session page = %+v, want exactly %q", page.Sessions, materialized.SessionID)

--- a/shared/client/lazy_chat_goal_reconnect_test.go
+++ b/shared/client/lazy_chat_goal_reconnect_test.go
@@ -46,8 +46,6 @@ type reconnectCountingConn struct {
 	inner        rpcwire.Conn
 	materializes *atomic.Int32
 	goalSets     *atomic.Int32
-	closed       chan struct{}
-	closedOnce   sync.Once
 }
 
 func newReconnectCountingConn(inner rpcwire.Conn, materializations, goalSets *atomic.Int32) *reconnectCountingConn {
@@ -55,12 +53,7 @@ func newReconnectCountingConn(inner rpcwire.Conn, materializations, goalSets *at
 		inner:        inner,
 		materializes: materializations,
 		goalSets:     goalSets,
-		closed:       make(chan struct{}),
 	}
-	go func() {
-		<-inner.Closed()
-		conn.closedOnce.Do(func() { close(conn.closed) })
-	}()
 	return conn
 }
 
@@ -79,14 +72,10 @@ func (c *reconnectCountingConn) Events() <-chan rpcwire.Event {
 }
 
 func (c *reconnectCountingConn) Closed() <-chan struct{} {
-	return c.closed
+	return c.inner.Closed()
 }
 
 func (c *reconnectCountingConn) Close() error {
-	return c.inner.Close()
-}
-
-func (c *reconnectCountingConn) Drop() error {
 	return c.inner.Close()
 }
 
@@ -139,7 +128,7 @@ func TestRemoteLazyChatMaterializationReconnectDoesNotReplayGoal(t *testing.T) {
 	if first == nil {
 		t.Fatal("materialization did not use the first physical connection")
 	}
-	if err := first.Drop(); err != nil {
+	if err := first.Close(); err != nil {
 		t.Fatalf("DropFirstConnection: %v", err)
 	}
 	select {


### PR DESCRIPTION
## Summary

Adds integration and reconnect coverage for lazy Chat Goal continuation across the existing two-operation flow: materialize the workspace Chat, plan/activate the Session, then use the ordinary Goal API.

Coverage includes:
- successful Goal acceptance and first model request with the materialized draft/settings preserved;
- unavailable `ask_question` capability rejection;
- Session-start admission rejection;
- post-acceptance provider failure preserving the durable Goal, draft, and Session;
- reconnect handoff proving no materialization or Goal replay and exactly one retained Session;
- exact runtime-owner release and rejected-request no-event assertions.

No production code, API contracts, specifications, Desktop code, coordinator, replay, rollback, recovery, or second materializer changes were added.

## Verification

- `go test ./server/core -run 'TestCoreLazyChat' -count=1`
- `go test ./shared/client -run 'TestRemoteLazyChatMaterializationReconnectDoesNotReplayGoal' -count=1`
- Previously completed affected-package suites for Core, session launch/runtime control, shared client/protocol/API contracts, and transport.
- `git diff --check`

## Diff size

Compared with `main` (`b1a7e902ee3b`):
- Gross: 777 additions, 3 deletions; 780 changed lines.
- Net: +774 lines.
- Production code: 0 gross / 0 net lines.
- Test code: 777 additions, 3 deletions; +774 net lines.
- Generated/docs/protocol artifacts: 0.

## Caveats and follow-up

The provider-failure slice uses a deterministic test client and waits for public runtime idle state before forced-close release. The reconnect slice uses a test-owned transport wrapper around the normal WebSocket transport. Broad repository server testing previously hit the repository's 300-second harness cap; focused and affected-package verification passed, and no production Go code changed.

## Tracking

- Kent task: KENT-385
- GitHub issue: none linked
