### PR TITLE
fix: separate divergent assistant streams

### DIFF
--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -394,7 +394,7 @@ func optionalStringsDiffer(left *string, right *string) bool {
 	return *left != *right
 }
 
-func assistantResponseTextExtendsStream(streamed string, candidate string) bool {
+func AssistantResponseTextExtendsStream(streamed string, candidate string) bool {
 	if candidate == "" {
 		return false
 	}
@@ -405,7 +405,7 @@ func assistantResponseTextExtendsStream(streamed string, candidate string) bool 
 }
 
 func completedAssistantTextReconcilesStream(streamed string, completed string) bool {
-	return assistantResponseTextExtendsStream(streamed, completed) ||
+	return AssistantResponseTextExtendsStream(streamed, completed) ||
 		(streamed != "" &&
 			completed != "" &&
 			(strings.TrimRightFunc(streamed, unicode.IsSpace) == completed ||

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -1193,6 +1193,44 @@ func TestGenerateStream_PrefersPhaseResolvedAssistantTextOverRawDeltaConcatenati
 	}
 }
 
+func TestGenerateStream_EmitsCommentaryThenFinalDeltasWithTheirOutputItemPhases(t *testing.T) {
+	transport := newOpenAIStreamTestTransport(t,
+		`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_commentary","type":"message","role":"assistant","phase":"commentary","content":[]}}`,
+		`{"type":"response.output_text.delta","output_index":0,"delta":"Checking sources."}`,
+		`{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_commentary","type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"Checking sources."}]}}`,
+		`{"type":"response.output_item.added","output_index":1,"item":{"id":"msg_final","type":"message","role":"assistant","phase":"final_answer","content":[]}}`,
+		`{"type":"response.output_text.delta","output_index":1,"delta":"Final answer."}`,
+		`{"type":"response.output_item.done","output_index":1,"item":{"id":"msg_final","type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Final answer."}]}}`,
+		`{"type":"response.completed","response":{"usage":{"input_tokens":2,"output_tokens":4,"total_tokens":6},"output":[{"id":"msg_commentary","type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"Checking sources."}]},{"id":"msg_final","type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Final answer."}]}]}}`,
+		`[DONE]`,
+	)
+
+	var deltas []AssistantDelta
+	resp, err := transport.GenerateStreamWithEvents(
+		context.Background(),
+		OpenAIRequest{SessionID: textutil.Value("test-session"), ToolChoiceMode: ToolChoiceModeAutomatic, Model: "gpt-5"},
+		StreamCallbacks{OnAssistantDelta: func(delta AssistantDelta) {
+			deltas = append(deltas, delta)
+		}},
+	)
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+	if len(deltas) != 2 ||
+		deltas[0].Text != "Checking sources." ||
+		deltas[0].Phase != MessagePhaseCommentary ||
+		deltas[1].Text != "Final answer." ||
+		deltas[1].Phase != MessagePhaseFinal {
+		t.Fatalf("assistant deltas = %+v, want commentary then final output-item phases", deltas)
+	}
+	if optionalStringValue(resp.AssistantText) != "Final answer." {
+		t.Fatalf("assistant text = %q, want final output item", optionalStringValue(resp.AssistantText))
+	}
+	if !resp.ProviderPhase.Is(MessagePhaseFinal) {
+		t.Fatalf("provider phase = %#v, want %q", resp.ProviderPhase, MessagePhaseFinal)
+	}
+}
+
 func TestGenerateStream_RepairsMissingAssistantOutputItemAtNonZeroOutputIndex(t *testing.T) {
 	transport := newOpenAIStreamTestTransport(t,
 		`{"type":"response.output_item.done","output_index":2,"item":{"id":"msg_2","type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Done"}]}}`,

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -411,7 +411,9 @@ func (s *chatStore) appendStreamingDelta(stepID string, baseRevision int64, base
 		s.streaming = &assistantStreamingState{metadata: nextMetadata, transcriptStreamID: &streamID}
 	}
 	s.streaming.text += delta
-	s.streaming.phase = phase
+	if phase != "" {
+		s.streaming.phase = phase
+	}
 	return assistantStreamingAppend{
 		metadata:           cloneAssistantStreamMetadata(s.streaming.metadata),
 		transcriptStreamID: cloneTranscriptStreamID(s.streaming.transcriptStreamID),

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -134,6 +134,13 @@ type assistantStreamingState struct {
 	phase              llm.MessagePhase
 }
 
+type assistantStreamingAppend struct {
+	metadata           *AssistantStreamMetadata
+	transcriptStreamID *uuid.UUID
+	supersededMetadata *AssistantStreamMetadata
+	supersededStreamID *uuid.UUID
+}
+
 type compactionCheckpoint struct {
 	Items []llm.ResponseItem
 }
@@ -382,20 +389,35 @@ func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, prov
 	}
 }
 
-func (s *chatStore) appendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) (*AssistantStreamMetadata, *uuid.UUID) {
+func (s *chatStore) appendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) assistantStreamingAppend {
 	if delta == "" {
-		return nil, nil
+		return assistantStreamingAppend{}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	nextMetadata := newAssistantStreamMetadata(stepID, baseRevision, baseCommittedEntryCount)
+	var supersededMetadata *AssistantStreamMetadata
+	var supersededStreamID *uuid.UUID
+	if s.streaming != nil &&
+		s.streaming.phase != "" &&
+		phase != "" &&
+		s.streaming.phase != phase {
+		supersededMetadata = cloneAssistantStreamMetadata(s.streaming.metadata)
+		supersededStreamID = cloneTranscriptStreamID(s.streaming.transcriptStreamID)
+		s.streaming = nil
+	}
 	if s.streaming == nil || assistantStreamingSegmentChanged(s.streaming.metadata, nextMetadata) {
 		streamID := uuid.New()
 		s.streaming = &assistantStreamingState{metadata: nextMetadata, transcriptStreamID: &streamID}
 	}
 	s.streaming.text += delta
 	s.streaming.phase = phase
-	return cloneAssistantStreamMetadata(s.streaming.metadata), cloneTranscriptStreamID(s.streaming.transcriptStreamID)
+	return assistantStreamingAppend{
+		metadata:           cloneAssistantStreamMetadata(s.streaming.metadata),
+		transcriptStreamID: cloneTranscriptStreamID(s.streaming.transcriptStreamID),
+		supersededMetadata: supersededMetadata,
+		supersededStreamID: supersededStreamID,
+	}
 }
 
 func (s *chatStore) streamingSnapshot() (string, string, *AssistantStreamMetadata) {

--- a/server/runtime/completed_response_stream_test.go
+++ b/server/runtime/completed_response_stream_test.go
@@ -41,7 +41,7 @@ func TestCompletedResponseActiveStreamFinalizesOnce(t *testing.T) {
 	}
 
 	var delta, assistant, reset *Event
-	deltaIndex, assistantIndex, resetIndex := -1, -1, -1
+	deltaIndex, resetIndex, assistantIndex := -1, -1, -1
 	for index := range events {
 		event := &events[index]
 		switch event.Kind {
@@ -68,8 +68,8 @@ func TestCompletedResponseActiveStreamFinalizesOnce(t *testing.T) {
 
 	if delta == nil || assistant == nil || reset == nil ||
 		delta.AssistantTranscriptStreamID == nil ||
-		assistant.AssistantTranscriptStreamID == nil ||
 		reset.AssistantTranscriptStreamID == nil ||
+		assistant.AssistantTranscriptStreamID != nil ||
 		assistant.Message.Role != llm.RoleAssistant ||
 		assistant.Message.Phase == nil ||
 		*assistant.Message.Phase != llm.MessagePhaseFinal ||
@@ -81,23 +81,110 @@ func TestCompletedResponseActiveStreamFinalizesOnce(t *testing.T) {
 			reset,
 		)
 	}
-	if deltaIndex >= assistantIndex || assistantIndex >= resetIndex {
+	if deltaIndex >= resetIndex || resetIndex >= assistantIndex {
 		t.Fatalf(
-			"stream finalization order = delta:%d assistant:%d reset:%d events:%+v",
+			"stream divergence order = delta:%d reset:%d assistant:%d events:%+v",
 			deltaIndex,
-			assistantIndex,
 			resetIndex,
+			assistantIndex,
 			events,
 		)
 	}
-	if *delta.AssistantTranscriptStreamID != *assistant.AssistantTranscriptStreamID ||
-		*delta.AssistantTranscriptStreamID != *reset.AssistantTranscriptStreamID {
+	if *delta.AssistantTranscriptStreamID != *reset.AssistantTranscriptStreamID ||
+		reset.AssistantStreamAbortReason != string(AssistantStreamAbortSuperseded) {
 		t.Fatalf(
-			"stream finalization UUIDs differ: delta:%s assistant:%s reset:%s",
+			"divergent stream terminal = delta:%s reset:%s reason:%q",
 			*delta.AssistantTranscriptStreamID,
-			*assistant.AssistantTranscriptStreamID,
 			*reset.AssistantTranscriptStreamID,
+			reset.AssistantStreamAbortReason,
 		)
+	}
+}
+
+func TestCompletedResponseFinalPhaseSupersedesCommentaryStream(t *testing.T) {
+	t.Parallel()
+	step := scriptedllm.FinalAnswer("completed")
+	step.StreamDeltas = []llm.AssistantDelta{
+		{Text: "I’m checking the relevant terminal behavior before answering.", Phase: llm.MessagePhaseCommentary},
+		{Text: "Yes — **Ghostty is likely the second actor**, but the user probably did **not** explicitly enable it.", Phase: llm.MessagePhaseFinal},
+	}
+	step.Response.Assistant.Content = textutil.Value("Yes — **Ghostty is likely the second actor**, but the user probably did **not** explicitly enable it.")
+	var events []Event
+	engine := mustNewExecTestEngine(
+		t,
+		mustCreateTestSession(t),
+		scriptedllm.NewClient(scriptedllm.Script{Steps: []scriptedllm.Step{step}}),
+		Config{
+			Model:   "gpt-5",
+			OnEvent: func(event Event) { events = append(events, event) },
+		},
+	)
+
+	if _, err := engine.SubmitUserMessage(context.Background(), "turn"); err != nil {
+		t.Fatalf("submit user turn: %v", err)
+	}
+
+	assertSupersededStreamPrecedesFinalContinuation(t, events, "assistant phase transition")
+}
+
+func TestCompletedResponseUnphasedDeltaJoinsFinalStream(t *testing.T) {
+	t.Parallel()
+	step := scriptedllm.FinalAnswer("completed")
+	step.StreamDeltas = []llm.AssistantDelta{
+		{Text: "complete"},
+		{Text: "d", Phase: llm.MessagePhaseFinal},
+	}
+	var events []Event
+	engine := mustNewExecTestEngine(
+		t,
+		mustCreateTestSession(t),
+		scriptedllm.NewClient(scriptedllm.Script{Steps: []scriptedllm.Step{step}}),
+		Config{
+			Model:   "gpt-5",
+			OnEvent: func(event Event) { events = append(events, event) },
+		},
+	)
+
+	if _, err := engine.SubmitUserMessage(context.Background(), "turn"); err != nil {
+		t.Fatalf("submit user turn: %v", err)
+	}
+
+	var firstDelta, secondDelta, finalAssistant *Event
+	resetCount := 0
+	for index := range events {
+		event := &events[index]
+		switch event.Kind {
+		case EventAssistantDelta:
+			if firstDelta == nil {
+				firstDelta = event
+			} else {
+				secondDelta = event
+			}
+		case EventAssistantDeltaReset:
+			if event.AssistantStreamAbortReason != "" {
+				resetCount++
+			}
+		case EventAssistantMessage:
+			finalAssistant = event
+		}
+	}
+	if firstDelta == nil || secondDelta == nil || finalAssistant == nil ||
+		firstDelta.AssistantTranscriptStreamID == nil ||
+		secondDelta.AssistantTranscriptStreamID == nil ||
+		finalAssistant.AssistantTranscriptStreamID == nil {
+		t.Fatalf("unphased final stream facts = first:%+v second:%+v final:%+v", firstDelta, secondDelta, finalAssistant)
+	}
+	if *firstDelta.AssistantTranscriptStreamID != *secondDelta.AssistantTranscriptStreamID ||
+		*secondDelta.AssistantTranscriptStreamID != *finalAssistant.AssistantTranscriptStreamID {
+		t.Fatalf(
+			"unphased final stream IDs = first:%s second:%s final:%s",
+			*firstDelta.AssistantTranscriptStreamID,
+			*secondDelta.AssistantTranscriptStreamID,
+			*finalAssistant.AssistantTranscriptStreamID,
+		)
+	}
+	if resetCount != 0 {
+		t.Fatalf("unphased final stream emitted %d superseded terminals", resetCount)
 	}
 }
 
@@ -169,7 +256,7 @@ func TestCompletedResponseWorkflowPreflightAbortsBeforeContinuation(t *testing.T
 	}}
 	accepted := scriptedllm.FinalAnswer(`{"transition":"done","summary":"done"}`)
 	accepted.StreamDeltas = []llm.AssistantDelta{{
-		Text:  "completed",
+		Text:  `{"transition"`,
 		Phase: llm.MessagePhaseFinal,
 	}}
 	var events []Event
@@ -300,7 +387,7 @@ func TestCompletedResponseReasoningOnlyAbortsBeforeContinuation(t *testing.T) {
 	}
 	final := scriptedllm.FinalAnswer("completed")
 	final.StreamDeltas = []llm.AssistantDelta{{
-		Text:  "resolved",
+		Text:  "complete",
 		Phase: llm.MessagePhaseFinal,
 	}}
 	var events []Event
@@ -414,7 +501,7 @@ func TestCompletedResponseFinalAnswerWithToolsFinalizesAfterToolPersistence(t *t
 	})
 	step.Response.Assistant.Phase = textutil.Value(llm.MessagePhaseFinal)
 	step.StreamDeltas = []llm.AssistantDelta{{
-		Text:  "draft",
+		Text:  "complete",
 		Phase: llm.MessagePhaseFinal,
 	}}
 	var events []Event
@@ -577,7 +664,7 @@ func TestSubmitUserMessageFinalAnswerWithMixedToolCallsMaterializesAllToolsBefor
 	}
 	step := scriptedllm.ToolBatch("completed", calls...)
 	step.Response.Assistant.Phase = textutil.Value(llm.MessagePhaseFinal)
-	step.StreamDeltas = []llm.AssistantDelta{{Text: "draft", Phase: llm.MessagePhaseFinal}}
+	step.StreamDeltas = []llm.AssistantDelta{{Text: "complete", Phase: llm.MessagePhaseFinal}}
 	reasoningOutput, reasoningPart := int64(0), int64(0)
 	step.ReasoningDeltas = []llm.ReasoningSummaryDelta{{
 		SourceCoordinate: &llm.ReasoningSourceCoordinate{

--- a/server/runtime/completed_response_stream_test.go
+++ b/server/runtime/completed_response_stream_test.go
@@ -188,6 +188,95 @@ func TestCompletedResponseUnphasedDeltaJoinsFinalStream(t *testing.T) {
 	}
 }
 
+func TestCompletedResponseUnphasedDeltaPreservesCommentaryBoundary(t *testing.T) {
+	t.Parallel()
+	step := scriptedllm.FinalAnswer("completed")
+	step.StreamDeltas = []llm.AssistantDelta{
+		{Text: "checking", Phase: llm.MessagePhaseCommentary},
+		{Text: " sources"},
+		{Text: "completed", Phase: llm.MessagePhaseFinal},
+	}
+	var events []Event
+	engine := mustNewExecTestEngine(
+		t,
+		mustCreateTestSession(t),
+		scriptedllm.NewClient(scriptedllm.Script{Steps: []scriptedllm.Step{step}}),
+		Config{
+			Model:   "gpt-5",
+			OnEvent: func(event Event) { events = append(events, event) },
+		},
+	)
+
+	if _, err := engine.SubmitUserMessage(context.Background(), "turn"); err != nil {
+		t.Fatalf("submit user turn: %v", err)
+	}
+
+	var commentary, unphased, reset, finalDelta, finalAssistant *Event
+	commentaryIndex, unphasedIndex, resetIndex, finalDeltaIndex, finalAssistantIndex := -1, -1, -1, -1, -1
+	for index := range events {
+		event := &events[index]
+		switch event.Kind {
+		case EventAssistantDelta:
+			switch event.AssistantDelta {
+			case "checking":
+				commentary, commentaryIndex = event, index
+			case " sources":
+				unphased, unphasedIndex = event, index
+			case "completed":
+				finalDelta, finalDeltaIndex = event, index
+			}
+		case EventAssistantDeltaReset:
+			if event.AssistantStreamAbortReason == string(AssistantStreamAbortSuperseded) {
+				reset, resetIndex = event, index
+			}
+		case EventAssistantMessage:
+			finalAssistant, finalAssistantIndex = event, index
+		}
+	}
+	if commentary == nil || unphased == nil || reset == nil || finalDelta == nil || finalAssistant == nil ||
+		commentary.AssistantTranscriptStreamID == nil ||
+		unphased.AssistantTranscriptStreamID == nil ||
+		reset.AssistantTranscriptStreamID == nil ||
+		finalDelta.AssistantTranscriptStreamID == nil ||
+		finalAssistant.AssistantTranscriptStreamID == nil {
+		t.Fatalf(
+			"unphased commentary transition = commentary:%+v unphased:%+v reset:%+v final_delta:%+v final:%+v",
+			commentary,
+			unphased,
+			reset,
+			finalDelta,
+			finalAssistant,
+		)
+	}
+	if *commentary.AssistantTranscriptStreamID != *unphased.AssistantTranscriptStreamID ||
+		*commentary.AssistantTranscriptStreamID != *reset.AssistantTranscriptStreamID ||
+		*commentary.AssistantTranscriptStreamID == *finalDelta.AssistantTranscriptStreamID ||
+		*finalDelta.AssistantTranscriptStreamID != *finalAssistant.AssistantTranscriptStreamID {
+		t.Fatalf(
+			"unphased commentary stream IDs = commentary:%s unphased:%s reset:%s final_delta:%s final:%s",
+			*commentary.AssistantTranscriptStreamID,
+			*unphased.AssistantTranscriptStreamID,
+			*reset.AssistantTranscriptStreamID,
+			*finalDelta.AssistantTranscriptStreamID,
+			*finalAssistant.AssistantTranscriptStreamID,
+		)
+	}
+	if commentaryIndex >= unphasedIndex ||
+		unphasedIndex >= resetIndex ||
+		resetIndex >= finalDeltaIndex ||
+		finalDeltaIndex >= finalAssistantIndex {
+		t.Fatalf(
+			"unphased commentary order = commentary:%d unphased:%d reset:%d final_delta:%d final:%d events:%+v",
+			commentaryIndex,
+			unphasedIndex,
+			resetIndex,
+			finalDeltaIndex,
+			finalAssistantIndex,
+			events,
+		)
+	}
+}
+
 func TestCompletedResponseWithoutActiveStreamPublishesNoStreamTerminal(t *testing.T) {
 	t.Parallel()
 	var events []Event

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -695,6 +695,20 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		if commit.result == nil {
 			return errors.New("assistant commit steering item requires a result destination")
 		}
+		if committedAssistantMessageFinalizesStreaming(commit.message) {
+			streamed, _, _ := e.transcriptRuntimeState().StreamingSnapshot()
+			finalText := ""
+			if commit.message.Content != nil {
+				finalText = *commit.message.Content
+			}
+			if streamed != "" && !strings.HasPrefix(finalText, streamed) {
+				outcome, resolveErr := e.resolveCompletedResponseStreamRaw(stepID, completedResponseAbortInstruction())
+				commit.result.resolution = outcome
+				if resolveErr != nil {
+					return resolveErr
+				}
+			}
+		}
 		receipt, err := e.appendMessageRaw(stepID, commit.message, steeringMessageEventNone, true, &commit.result.provenance)
 		item.recordCommitReceipt(receipt)
 		if err != nil || !receipt.Committed {
@@ -980,8 +994,26 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 			if err != nil {
 				return err
 			}
-			metadata, streamID := e.transcriptRuntimeState().AppendStreamingDelta(stepID, revision, e.CommittedTranscriptEntryCount(), delta.Text, delta.Phase)
-			return e.emitRaw(Event{Kind: EventAssistantDelta, StepID: stepID, AssistantDelta: delta.Text, AssistantDeltaPhase: delta.Phase, AssistantStreamMetadata: metadata, AssistantTranscriptStreamID: streamID})
+			appended := e.transcriptRuntimeState().AppendStreamingDelta(stepID, revision, e.CommittedTranscriptEntryCount(), delta.Text, delta.Phase)
+			if appended.supersededStreamID != nil {
+				reason := AssistantStreamAbortSuperseded
+				if err := e.emitStreamingAssistantCleanupEventsRaw(
+					stepID,
+					appended.supersededMetadata,
+					appended.supersededStreamID,
+					&reason,
+				); err != nil {
+					return err
+				}
+			}
+			return e.emitRaw(Event{
+				Kind:                        EventAssistantDelta,
+				StepID:                      stepID,
+				AssistantDelta:              delta.Text,
+				AssistantDeltaPhase:         delta.Phase,
+				AssistantStreamMetadata:     appended.metadata,
+				AssistantTranscriptStreamID: appended.transcriptStreamID,
+			})
 		}
 		if item.streaming.reasoningDelta != nil {
 			delta := *item.streaming.reasoningDelta

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -701,7 +701,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 			if commit.message.Content != nil {
 				finalText = *commit.message.Content
 			}
-			if streamed != "" && !strings.HasPrefix(finalText, streamed) {
+			if streamed != "" && !llm.AssistantResponseTextExtendsStream(streamed, finalText) {
 				outcome, resolveErr := e.resolveCompletedResponseStreamRaw(stepID, completedResponseAbortInstruction())
 				commit.result.resolution = outcome
 				if resolveErr != nil {

--- a/server/runtime/transcript_runtime_state.go
+++ b/server/runtime/transcript_runtime_state.go
@@ -484,7 +484,7 @@ func (s *transcriptRuntimeState) AppendCommittedEntryWithVisibility(role, text s
 	s.chatProjection().appendLocalEntryRecord(ChatEntry{Visibility: visibility, Role: role, Text: text}, nil, provenances...)
 }
 
-func (s *transcriptRuntimeState) AppendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) (*AssistantStreamMetadata, *uuid.UUID) {
+func (s *transcriptRuntimeState) AppendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) assistantStreamingAppend {
 	return s.chatProjection().appendStreamingDelta(stepID, baseRevision, baseCommittedEntryCount, delta, phase)
 }
 


### PR DESCRIPTION
## Summary

- terminate the active assistant stream when explicit assistant phase changes before emitting the new phase
- reject stale stream identity at finalization when committed assistant text does not extend the active stream
- preserve unphased compatible-provider deltas within the current stream
- keep the TUI's append-only finalization invariant strict

## Root cause

The captured TUI panic reported a 2,166-byte active source and a 1,944-byte committed final under the same stream ID. Runtime allowed both explicit phase changes and same-phase non-prefix committed text to retain one Streaming Message identity. Once the TUI had promoted bytes from that stream into immutable scrollback, the shorter/different committed row could not safely finalize it.

The persisted log proves the stream/final mismatch, but does not retain raw provider stream events. A deterministic OpenAI transport fixture now covers commentary output-item deltas followed by final-answer output-item deltas.

## Behavior

- An explicit commentary/final phase transition supersedes the old stream before the new delta is published.
- If committed final text does not extend an active same-phase stream, Kent aborts the stale stream before persisting/publishing the committed row. The committed row is published without the stale stream ID.
- If committed text extends the active stream, ordinary suffix finalization is unchanged.
- Unphased deltas remain compatible and do not create artificial stream boundaries.

## Verification

- `./scripts/test.sh ./server/llm -count=1`
- `./scripts/test.sh ./server/runtime -count=1`
- `./scripts/test.sh ./server/runtimeview -count=1`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check`
- merge simulation against PR #796's current head reported no conflicts

A broader `./scripts/test.sh server` run was attempted earlier and reached the repository's 300-second harness cap in unrelated workflow tests without reporting a test failure; the complete affected package suites above pass.
