### PR TITLE
fix: migrate and restore retained assignment state

### DIFF
--- a/server/metadata/session_metadata_document_test.go
+++ b/server/metadata/session_metadata_document_test.go
@@ -32,6 +32,10 @@ func TestSessionMetadataDocumentRoundTripsWorkflowNeutralFields(t *testing.T) {
 			CreatedAt: createdAt,
 			UpdatedAt: createdAt,
 		},
+		ActiveWorkflowAssignment: &session.MessageRecord{
+			Role: session.MessageRoleDeveloper,
+		},
+		ActiveWorkflowAssignmentState: &session.ActiveWorkflowAssignmentState{},
 	}
 
 	encoded, err := marshalJSON(document)

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -65,17 +65,19 @@ type Store struct {
 }
 
 type sessionMetadataDocument struct {
-	WorkspaceRoot                   string                         `json:"workspace_root"`
-	WorkspaceContainer              string                         `json:"workspace_container"`
-	ChatSettings                    *session.ChatSettingsOverrides `json:"chat_settings,omitempty"`
-	ConversationEstablished         bool                           `json:"conversation_established"`
-	PromptCacheLineageGeneration    int                            `json:"prompt_cache_lineage_generation"`
-	HeadlessActive                  bool                           `json:"headless_active"`
-	CompactionSoonReminderIssued    bool                           `json:"compaction_soon_reminder_issued"`
-	GeneratedRecoveredWarningIssued bool                           `json:"generated_recovered_warning_issued"`
-	PendingModelRecovery            *session.PendingModelRecovery  `json:"pending_model_recovery"`
-	WorktreeReminder                *session.WorktreeReminderState `json:"worktree_reminder"`
-	Goal                            *session.GoalState             `json:"goal"`
+	WorkspaceRoot                   string                                 `json:"workspace_root"`
+	WorkspaceContainer              string                                 `json:"workspace_container"`
+	ChatSettings                    *session.ChatSettingsOverrides         `json:"chat_settings,omitempty"`
+	ConversationEstablished         bool                                   `json:"conversation_established"`
+	PromptCacheLineageGeneration    int                                    `json:"prompt_cache_lineage_generation"`
+	HeadlessActive                  bool                                   `json:"headless_active"`
+	CompactionSoonReminderIssued    bool                                   `json:"compaction_soon_reminder_issued"`
+	GeneratedRecoveredWarningIssued bool                                   `json:"generated_recovered_warning_issued"`
+	PendingModelRecovery            *session.PendingModelRecovery          `json:"pending_model_recovery"`
+	WorktreeReminder                *session.WorktreeReminderState         `json:"worktree_reminder"`
+	Goal                            *session.GoalState                     `json:"goal"`
+	ActiveWorkflowAssignment        *session.MessageRecord                 `json:"active_workflow_assignment,omitempty"`
+	ActiveWorkflowAssignmentState   *session.ActiveWorkflowAssignmentState `json:"active_workflow_assignment_state,omitempty"`
 }
 
 var (
@@ -2497,6 +2499,8 @@ func (s *Store) upsertSessionSnapshotWithQueries(
 		PendingModelRecovery:            snapshot.Meta.PendingModelRecovery,
 		WorktreeReminder:                persistedWorktreeReminder,
 		Goal:                            snapshot.Meta.Goal,
+		ActiveWorkflowAssignment:        snapshot.Meta.ActiveWorkflowAssignment,
+		ActiveWorkflowAssignmentState:   snapshot.Meta.ActiveWorkflowAssignmentState,
 	})
 	if err != nil {
 		return err
@@ -2694,6 +2698,8 @@ func sessionMetaFromRecordRow(row sqlitegen.GetSessionRecordByIDRow) (session.Me
 		PendingModelRecovery:            metadataPayload.PendingModelRecovery,
 		WorktreeReminder:                metadataPayload.WorktreeReminder,
 		Goal:                            metadataPayload.Goal,
+		ActiveWorkflowAssignment:        metadataPayload.ActiveWorkflowAssignment,
+		ActiveWorkflowAssignmentState:   metadataPayload.ActiveWorkflowAssignmentState,
 		UsageState:                      usageState,
 		Locked:                          locked,
 	}, nil

--- a/server/runtime/workflow_assignment.go
+++ b/server/runtime/workflow_assignment.go
@@ -105,12 +105,17 @@ func (e *Engine) SteerWorkflowAssignmentSnapshot(snapshot WorkflowAssignmentSnap
 	if err := validateWorkflowAssignmentSnapshot(snapshot); err != nil {
 		return WorkflowAssignmentSteer{}, err
 	}
-	if snapshot.thinking != nil {
-		if err := e.setThinkingValue(*snapshot.thinking); err != nil {
-			return WorkflowAssignmentSteer{}, err
-		}
+	if err := e.RestoreWorkflowAssignmentSnapshotThinking(snapshot); err != nil {
+		return WorkflowAssignmentSteer{}, err
 	}
 	return e.steerWorkflowAssignmentMessage(snapshot.restorationMessage())
+}
+
+func (e *Engine) RestoreWorkflowAssignmentSnapshotThinking(snapshot WorkflowAssignmentSnapshot) error {
+	if snapshot.thinking == nil {
+		return nil
+	}
+	return e.setThinkingValue(*snapshot.thinking)
 }
 
 func (e *Engine) steerWorkflowAssignmentMessage(message llm.Message) (WorkflowAssignmentSteer, error) {
@@ -151,6 +156,9 @@ func CapturePersistedWorkflowAssignment(
 ) (WorkflowAssignmentSnapshot, bool, error) {
 	if store == nil {
 		return WorkflowAssignmentSnapshot{}, false, errors.New("session store is required")
+	}
+	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
+		return WorkflowAssignmentSnapshot{}, false, err
 	}
 	meta := store.Meta()
 	snapshot := WorkflowAssignmentSnapshot{}

--- a/server/runtime/workflow_assignment.go
+++ b/server/runtime/workflow_assignment.go
@@ -157,13 +157,14 @@ func CapturePersistedWorkflowAssignment(
 	if store == nil {
 		return WorkflowAssignmentSnapshot{}, false, errors.New("session store is required")
 	}
-	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
+	activeAssignment, err := store.ActiveWorkflowAssignmentProjection()
+	if err != nil {
 		return WorkflowAssignmentSnapshot{}, false, err
 	}
 	meta := store.Meta()
 	snapshot := WorkflowAssignmentSnapshot{}
-	if meta.ActiveWorkflowAssignment != nil {
-		message, err := llmMessageFromSessionRecord(*meta.ActiveWorkflowAssignment)
+	if activeAssignment != nil {
+		message, err := llmMessageFromSessionRecord(*activeAssignment)
 		if err != nil {
 			return WorkflowAssignmentSnapshot{}, false, err
 		}

--- a/server/session/event_log_capability_append.go
+++ b/server/session/event_log_capability_append.go
@@ -359,14 +359,14 @@ func advanceActiveWorkflowAssignmentFromRecords(meta *Meta, records []EventRecor
 			switch *value.MessageType {
 			case MessageTypeWorkflowMode:
 				meta.ActiveWorkflowAssignment = cloneMessageRecord(&value)
-				meta.ActiveWorkflowAssignmentKnown = true
+				meta.ActiveWorkflowAssignmentState = &ActiveWorkflowAssignmentState{}
 			case MessageTypeWorkflowModeExit:
 				meta.ActiveWorkflowAssignment = nil
-				meta.ActiveWorkflowAssignmentKnown = true
+				meta.ActiveWorkflowAssignmentState = &ActiveWorkflowAssignmentState{}
 			}
 		case HistoryReplacementRecord:
 			meta.ActiveWorkflowAssignment = nil
-			meta.ActiveWorkflowAssignmentKnown = true
+			meta.ActiveWorkflowAssignmentState = &ActiveWorkflowAssignmentState{}
 			for _, item := range value.Items {
 				if item.Type != ProviderHistoryItemTypeMessage ||
 					item.Role == nil ||

--- a/server/session/event_log_capability_append.go
+++ b/server/session/event_log_capability_append.go
@@ -359,11 +359,14 @@ func advanceActiveWorkflowAssignmentFromRecords(meta *Meta, records []EventRecor
 			switch *value.MessageType {
 			case MessageTypeWorkflowMode:
 				meta.ActiveWorkflowAssignment = cloneMessageRecord(&value)
+				meta.ActiveWorkflowAssignmentKnown = true
 			case MessageTypeWorkflowModeExit:
 				meta.ActiveWorkflowAssignment = nil
+				meta.ActiveWorkflowAssignmentKnown = true
 			}
 		case HistoryReplacementRecord:
 			meta.ActiveWorkflowAssignment = nil
+			meta.ActiveWorkflowAssignmentKnown = true
 			for _, item := range value.Items {
 				if item.Type != ProviderHistoryItemTypeMessage ||
 					item.Role == nil ||

--- a/server/session/meta_clone.go
+++ b/server/session/meta_clone.go
@@ -28,7 +28,15 @@ func cloneMeta(in Meta) Meta {
 	}
 	out.Locked = cloneLockedContract(in.Locked)
 	out.ActiveWorkflowAssignment = cloneMessageRecord(in.ActiveWorkflowAssignment)
+	out.ActiveWorkflowAssignmentState = cloneActiveWorkflowAssignmentState(in.ActiveWorkflowAssignmentState)
 	return out
+}
+
+func cloneActiveWorkflowAssignmentState(in *ActiveWorkflowAssignmentState) *ActiveWorkflowAssignmentState {
+	if in == nil {
+		return nil
+	}
+	return &ActiveWorkflowAssignmentState{}
 }
 
 func cloneMessageRecord(in *MessageRecord) *MessageRecord {

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -258,12 +258,13 @@ func newLazyWithIDAndStoreOptions(sessionID runtimeids.SessionID, workspaceConta
 		eventsFP:   filepath.Join(sessionDir, eventsFile),
 		options:    storeOpts,
 		meta: Meta{
-			SessionID:          sid,
-			Category:           sessionCategoryPointer(validatedCategory),
-			WorkspaceRoot:      workspaceRoot,
-			WorkspaceContainer: workspaceContainerName,
-			CreatedAt:          now,
-			UpdatedAt:          now,
+			SessionID:                     sid,
+			Category:                      sessionCategoryPointer(validatedCategory),
+			WorkspaceRoot:                 workspaceRoot,
+			WorkspaceContainer:            workspaceContainerName,
+			CreatedAt:                     now,
+			UpdatedAt:                     now,
+			ActiveWorkflowAssignmentKnown: true,
 		},
 		conversationFreshness: ConversationFreshnessFresh,
 		persisted:             false,
@@ -545,13 +546,14 @@ func (s *Store) Meta() Meta {
 func (s *Store) PromptFacingMetadataSnapshot() PromptFacingMetadataSnapshot {
 	meta := s.Meta()
 	return PromptFacingMetadataSnapshot{
-		Name:                         meta.Name,
-		FirstPromptPreview:           meta.FirstPromptPreview,
-		Continuation:                 cloneContinuationContext(meta.Continuation),
-		ChatSettings:                 cloneChatSettingsOverrides(meta.ChatSettings),
-		PromptCacheLineageGeneration: meta.PromptCacheLineageGeneration,
-		Locked:                       cloneLockedContract(meta.Locked),
-		ActiveWorkflowAssignment:     cloneMessageRecord(meta.ActiveWorkflowAssignment),
+		Name:                          meta.Name,
+		FirstPromptPreview:            meta.FirstPromptPreview,
+		Continuation:                  cloneContinuationContext(meta.Continuation),
+		ChatSettings:                  cloneChatSettingsOverrides(meta.ChatSettings),
+		PromptCacheLineageGeneration:  meta.PromptCacheLineageGeneration,
+		Locked:                        cloneLockedContract(meta.Locked),
+		ActiveWorkflowAssignment:      cloneMessageRecord(meta.ActiveWorkflowAssignment),
+		ActiveWorkflowAssignmentKnown: meta.ActiveWorkflowAssignmentKnown,
 	}
 }
 
@@ -564,6 +566,7 @@ func (s *Store) RestorePromptFacingMetadata(snapshot PromptFacingMetadataSnapsho
 		s.meta.PromptCacheLineageGeneration = snapshot.PromptCacheLineageGeneration
 		s.meta.Locked = cloneLockedContract(snapshot.Locked)
 		s.meta.ActiveWorkflowAssignment = cloneMessageRecord(snapshot.ActiveWorkflowAssignment)
+		s.meta.ActiveWorkflowAssignmentKnown = snapshot.ActiveWorkflowAssignmentKnown
 		s.meta.UpdatedAt = time.Now().UTC()
 		return nil
 	})

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -264,7 +264,7 @@ func newLazyWithIDAndStoreOptions(sessionID runtimeids.SessionID, workspaceConta
 			WorkspaceContainer:            workspaceContainerName,
 			CreatedAt:                     now,
 			UpdatedAt:                     now,
-			ActiveWorkflowAssignmentKnown: true,
+			ActiveWorkflowAssignmentState: &ActiveWorkflowAssignmentState{},
 		},
 		conversationFreshness: ConversationFreshnessFresh,
 		persisted:             false,
@@ -553,7 +553,7 @@ func (s *Store) PromptFacingMetadataSnapshot() PromptFacingMetadataSnapshot {
 		PromptCacheLineageGeneration:  meta.PromptCacheLineageGeneration,
 		Locked:                        cloneLockedContract(meta.Locked),
 		ActiveWorkflowAssignment:      cloneMessageRecord(meta.ActiveWorkflowAssignment),
-		ActiveWorkflowAssignmentKnown: meta.ActiveWorkflowAssignmentKnown,
+		ActiveWorkflowAssignmentState: cloneActiveWorkflowAssignmentState(meta.ActiveWorkflowAssignmentState),
 	}
 }
 
@@ -566,7 +566,7 @@ func (s *Store) RestorePromptFacingMetadata(snapshot PromptFacingMetadataSnapsho
 		s.meta.PromptCacheLineageGeneration = snapshot.PromptCacheLineageGeneration
 		s.meta.Locked = cloneLockedContract(snapshot.Locked)
 		s.meta.ActiveWorkflowAssignment = cloneMessageRecord(snapshot.ActiveWorkflowAssignment)
-		s.meta.ActiveWorkflowAssignmentKnown = snapshot.ActiveWorkflowAssignmentKnown
+		s.meta.ActiveWorkflowAssignmentState = cloneActiveWorkflowAssignmentState(snapshot.ActiveWorkflowAssignmentState)
 		s.meta.UpdatedAt = time.Now().UTC()
 		return nil
 	})

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -217,8 +217,12 @@ type Meta struct {
 	Goal                            *GoalState                       `json:"goal,omitempty"`
 	Locked                          *LockedContract                  `json:"locked,omitempty"`
 	ActiveWorkflowAssignment        *MessageRecord                   `json:"active_workflow_assignment,omitempty"`
-	ActiveWorkflowAssignmentKnown   bool                             `json:"active_workflow_assignment_known,omitempty"`
+	ActiveWorkflowAssignmentState   *ActiveWorkflowAssignmentState   `json:"active_workflow_assignment_state,omitempty"`
 }
+
+// ActiveWorkflowAssignmentState marks an authoritative projection, including
+// the valid state where no executable Workflow assignment is active.
+type ActiveWorkflowAssignmentState struct{}
 
 // PromptFacingMetadataSnapshot captures metadata that Session planning may
 // change before a Workflow assignment commits.
@@ -230,7 +234,7 @@ type PromptFacingMetadataSnapshot struct {
 	PromptCacheLineageGeneration  int
 	Locked                        *LockedContract
 	ActiveWorkflowAssignment      *MessageRecord
-	ActiveWorkflowAssignmentKnown bool
+	ActiveWorkflowAssignmentState *ActiveWorkflowAssignmentState
 }
 
 type PendingModelRecovery struct {

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -217,18 +217,20 @@ type Meta struct {
 	Goal                            *GoalState                       `json:"goal,omitempty"`
 	Locked                          *LockedContract                  `json:"locked,omitempty"`
 	ActiveWorkflowAssignment        *MessageRecord                   `json:"active_workflow_assignment,omitempty"`
+	ActiveWorkflowAssignmentKnown   bool                             `json:"active_workflow_assignment_known,omitempty"`
 }
 
 // PromptFacingMetadataSnapshot captures metadata that Session planning may
 // change before a Workflow assignment commits.
 type PromptFacingMetadataSnapshot struct {
-	Name                         string
-	FirstPromptPreview           string
-	Continuation                 *ContinuationContext
-	ChatSettings                 *ChatSettingsOverrides
-	PromptCacheLineageGeneration int
-	Locked                       *LockedContract
-	ActiveWorkflowAssignment     *MessageRecord
+	Name                          string
+	FirstPromptPreview            string
+	Continuation                  *ContinuationContext
+	ChatSettings                  *ChatSettingsOverrides
+	PromptCacheLineageGeneration  int
+	Locked                        *LockedContract
+	ActiveWorkflowAssignment      *MessageRecord
+	ActiveWorkflowAssignmentKnown bool
 }
 
 type PendingModelRecovery struct {

--- a/server/session/workflow_assignment_projection.go
+++ b/server/session/workflow_assignment_projection.go
@@ -1,80 +1,21 @@
 package session
 
-import (
-	"errors"
-	"fmt"
-)
-
-const activeWorkflowAssignmentMigrationWindow = 256
+import "errors"
 
 var ErrActiveWorkflowAssignmentProjectionUnavailable = errors.New(
 	"active workflow assignment projection is unavailable",
 )
 
-// EnsureActiveWorkflowAssignmentProjection performs a bounded, one-time
-// initialization for Sessions created before the projection was persisted.
-func (s *Store) EnsureActiveWorkflowAssignmentProjection() error {
+// ActiveWorkflowAssignmentProjection returns the authoritative current
+// assignment. A nil assignment is valid only when the persisted state marker
+// proves that absence.
+func (s *Store) ActiveWorkflowAssignmentProjection() (*MessageRecord, error) {
 	if s == nil {
-		return errors.New("session store is required")
+		return nil, errors.New("session store is required")
 	}
-	if s.Meta().ActiveWorkflowAssignmentKnown {
-		return nil
+	meta := s.Meta()
+	if meta.ActiveWorkflowAssignmentState == nil && meta.ActiveWorkflowAssignment == nil {
+		return nil, ErrActiveWorkflowAssignmentProjectionUnavailable
 	}
-	eventLog, err := s.MaterializeEventLog()
-	if err != nil {
-		return err
-	}
-	window, err := eventLog.ReadRecentRecords(activeWorkflowAssignmentMigrationWindow)
-	if err != nil {
-		return err
-	}
-	var (
-		projected *MessageRecord
-		resolved  bool
-	)
-	for index := len(window.Records) - 1; index >= 0; index-- {
-		record := window.Records[index]
-		payload, payloadErr := record.Payload()
-		if payloadErr != nil {
-			return payloadErr
-		}
-		switch value := payload.(type) {
-		case MessageRecord:
-			if value.MessageType == nil {
-				continue
-			}
-			switch *value.MessageType {
-			case MessageTypeWorkflowMode:
-				projected = cloneMessageRecord(&value)
-				resolved = true
-			case MessageTypeWorkflowModeExit:
-				resolved = true
-			}
-		case HistoryReplacementRecord:
-			meta := Meta{}
-			if projectionErr := advanceActiveWorkflowAssignmentFromRecords(&meta, []EventRecord{record}); projectionErr != nil {
-				return projectionErr
-			}
-			projected = cloneMessageRecord(meta.ActiveWorkflowAssignment)
-			resolved = true
-		}
-		if resolved {
-			break
-		}
-	}
-	if !resolved && !window.ReachedStart {
-		return fmt.Errorf(
-			"%w within the most recent %d records",
-			ErrActiveWorkflowAssignmentProjectionUnavailable,
-			activeWorkflowAssignmentMigrationWindow,
-		)
-	}
-	return s.mutateAndPersist(func() error {
-		if s.meta.ActiveWorkflowAssignmentKnown {
-			return nil
-		}
-		s.meta.ActiveWorkflowAssignment = cloneMessageRecord(projected)
-		s.meta.ActiveWorkflowAssignmentKnown = true
-		return nil
-	})
+	return cloneMessageRecord(meta.ActiveWorkflowAssignment), nil
 }

--- a/server/session/workflow_assignment_projection.go
+++ b/server/session/workflow_assignment_projection.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+)
+
+const activeWorkflowAssignmentMigrationWindow = 256
+
+var ErrActiveWorkflowAssignmentProjectionUnavailable = errors.New(
+	"active workflow assignment projection is unavailable",
+)
+
+// EnsureActiveWorkflowAssignmentProjection performs a bounded, one-time
+// initialization for Sessions created before the projection was persisted.
+func (s *Store) EnsureActiveWorkflowAssignmentProjection() error {
+	if s == nil {
+		return errors.New("session store is required")
+	}
+	if s.Meta().ActiveWorkflowAssignmentKnown {
+		return nil
+	}
+	eventLog, err := s.MaterializeEventLog()
+	if err != nil {
+		return err
+	}
+	window, err := eventLog.ReadRecentRecords(activeWorkflowAssignmentMigrationWindow)
+	if err != nil {
+		return err
+	}
+	var (
+		projected *MessageRecord
+		resolved  bool
+	)
+	for index := len(window.Records) - 1; index >= 0; index-- {
+		record := window.Records[index]
+		payload, payloadErr := record.Payload()
+		if payloadErr != nil {
+			return payloadErr
+		}
+		switch value := payload.(type) {
+		case MessageRecord:
+			if value.MessageType == nil {
+				continue
+			}
+			switch *value.MessageType {
+			case MessageTypeWorkflowMode:
+				projected = cloneMessageRecord(&value)
+				resolved = true
+			case MessageTypeWorkflowModeExit:
+				resolved = true
+			}
+		case HistoryReplacementRecord:
+			meta := Meta{}
+			if projectionErr := advanceActiveWorkflowAssignmentFromRecords(&meta, []EventRecord{record}); projectionErr != nil {
+				return projectionErr
+			}
+			projected = cloneMessageRecord(meta.ActiveWorkflowAssignment)
+			resolved = true
+		}
+		if resolved {
+			break
+		}
+	}
+	if !resolved && !window.ReachedStart {
+		return fmt.Errorf(
+			"%w within the most recent %d records",
+			ErrActiveWorkflowAssignmentProjectionUnavailable,
+			activeWorkflowAssignmentMigrationWindow,
+		)
+	}
+	return s.mutateAndPersist(func() error {
+		if s.meta.ActiveWorkflowAssignmentKnown {
+			return nil
+		}
+		s.meta.ActiveWorkflowAssignment = cloneMessageRecord(projected)
+		s.meta.ActiveWorkflowAssignmentKnown = true
+		return nil
+	})
+}

--- a/server/session/workflow_assignment_projection_test.go
+++ b/server/session/workflow_assignment_projection_test.go
@@ -2,97 +2,35 @@ package session
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 )
 
-func TestEnsureActiveWorkflowAssignmentProjectionMigratesRecentAssignment(t *testing.T) {
+func TestActiveWorkflowAssignmentProjectionDistinguishesKnownAbsenceFromMissingState(t *testing.T) {
 	store := newSessionTestLazyStore(t)
-	if err := store.EnsureDurable(); err != nil {
-		t.Fatalf("ensure durable Session: %v", err)
+	assignment, err := store.ActiveWorkflowAssignmentProjection()
+	if err != nil || assignment != nil {
+		t.Fatalf("fresh Session projection = %+v, %v; want known absence", assignment, err)
 	}
+
+	store.meta.ActiveWorkflowAssignmentState = nil
+	if _, err := store.ActiveWorkflowAssignmentProjection(); !errors.Is(err, ErrActiveWorkflowAssignmentProjectionUnavailable) {
+		t.Fatalf("missing projection marker error = %v", err)
+	}
+}
+
+func TestActiveWorkflowAssignmentProjectionTrustsPersistedParentAssignment(t *testing.T) {
+	store := newSessionTestLazyStore(t)
 	messageType := MessageTypeWorkflowMode
-	sourcePath := "workflow/task/node"
-	content := "assignment"
-	eventLog, err := store.MaterializeEventLog()
-	if err != nil {
-		t.Fatalf("materialize event log: %v", err)
-	}
-	if _, receipt, err := eventLog.AppendRecord(nil, MessageRecord{
+	content := "persisted assignment"
+	store.meta.ActiveWorkflowAssignmentState = nil
+	store.meta.ActiveWorkflowAssignment = &MessageRecord{
 		Role:        MessageRoleDeveloper,
 		MessageType: &messageType,
-		SourcePath:  &sourcePath,
 		Content:     &content,
-	}); err != nil || !receipt.Committed {
-		t.Fatalf("append legacy workflow assignment = %+v, %v", receipt, err)
-	}
-	if err := store.mutateAndPersist(func() error {
-		store.meta.ActiveWorkflowAssignment = nil
-		store.meta.ActiveWorkflowAssignmentKnown = false
-		return nil
-	}); err != nil {
-		t.Fatalf("simulate pre-projection Session: %v", err)
 	}
 
-	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
-		t.Fatalf("migrate active workflow assignment projection: %v", err)
-	}
-	meta := store.Meta()
-	if !meta.ActiveWorkflowAssignmentKnown ||
-		meta.ActiveWorkflowAssignment == nil ||
-		meta.ActiveWorkflowAssignment.SourcePath == nil ||
-		*meta.ActiveWorkflowAssignment.SourcePath != sourcePath {
-		t.Fatalf("migrated active workflow assignment = %+v", meta.ActiveWorkflowAssignment)
-	}
-}
-
-func TestEnsureActiveWorkflowAssignmentProjectionMigratesAbsentAssignment(t *testing.T) {
-	store := newSessionTestLazyStore(t)
-	if err := store.EnsureDurable(); err != nil {
-		t.Fatalf("ensure durable Session: %v", err)
-	}
-	if err := store.mutateAndPersist(func() error {
-		store.meta.ActiveWorkflowAssignmentKnown = false
-		return nil
-	}); err != nil {
-		t.Fatalf("simulate pre-projection empty Session: %v", err)
-	}
-
-	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
-		t.Fatalf("migrate absent workflow assignment projection: %v", err)
-	}
-	meta := store.Meta()
-	if !meta.ActiveWorkflowAssignmentKnown || meta.ActiveWorkflowAssignment != nil {
-		t.Fatalf("migrated absent workflow assignment state = known %v assignment %+v", meta.ActiveWorkflowAssignmentKnown, meta.ActiveWorkflowAssignment)
-	}
-}
-
-func TestEnsureActiveWorkflowAssignmentProjectionDoesNotScanPastBoundedWindow(t *testing.T) {
-	store := newSessionTestLazyStore(t)
-	if err := store.EnsureDurable(); err != nil {
-		t.Fatalf("ensure durable Session: %v", err)
-	}
-	eventLog, err := store.MaterializeEventLog()
-	if err != nil {
-		t.Fatalf("materialize event log: %v", err)
-	}
-	payloads := make([]EventRecordPayload, activeWorkflowAssignmentMigrationWindow+1)
-	for index := range payloads {
-		content := fmt.Sprintf("ordinary message %d", index)
-		payloads[index] = MessageRecord{Role: MessageRoleUser, Content: &content}
-	}
-	if _, receipt, err := eventLog.AppendRecordsAtomic(nil, payloads); err != nil || !receipt.Committed {
-		t.Fatalf("append migration-window fixture = %+v, %v", receipt, err)
-	}
-	if err := store.mutateAndPersist(func() error {
-		store.meta.ActiveWorkflowAssignmentKnown = false
-		return nil
-	}); err != nil {
-		t.Fatalf("simulate unresolved pre-projection Session: %v", err)
-	}
-
-	err = store.EnsureActiveWorkflowAssignmentProjection()
-	if !errors.Is(err, ErrActiveWorkflowAssignmentProjectionUnavailable) {
-		t.Fatalf("projection migration error = %v, want bounded-window unavailable", err)
+	assignment, err := store.ActiveWorkflowAssignmentProjection()
+	if err != nil || assignment == nil || assignment.Content == nil || *assignment.Content != content {
+		t.Fatalf("persisted parent projection = %+v, %v", assignment, err)
 	}
 }

--- a/server/session/workflow_assignment_projection_test.go
+++ b/server/session/workflow_assignment_projection_test.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestEnsureActiveWorkflowAssignmentProjectionMigratesRecentAssignment(t *testing.T) {
+	store := newSessionTestLazyStore(t)
+	if err := store.EnsureDurable(); err != nil {
+		t.Fatalf("ensure durable Session: %v", err)
+	}
+	messageType := MessageTypeWorkflowMode
+	sourcePath := "workflow/task/node"
+	content := "assignment"
+	eventLog, err := store.MaterializeEventLog()
+	if err != nil {
+		t.Fatalf("materialize event log: %v", err)
+	}
+	if _, receipt, err := eventLog.AppendRecord(nil, MessageRecord{
+		Role:        MessageRoleDeveloper,
+		MessageType: &messageType,
+		SourcePath:  &sourcePath,
+		Content:     &content,
+	}); err != nil || !receipt.Committed {
+		t.Fatalf("append legacy workflow assignment = %+v, %v", receipt, err)
+	}
+	if err := store.mutateAndPersist(func() error {
+		store.meta.ActiveWorkflowAssignment = nil
+		store.meta.ActiveWorkflowAssignmentKnown = false
+		return nil
+	}); err != nil {
+		t.Fatalf("simulate pre-projection Session: %v", err)
+	}
+
+	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
+		t.Fatalf("migrate active workflow assignment projection: %v", err)
+	}
+	meta := store.Meta()
+	if !meta.ActiveWorkflowAssignmentKnown ||
+		meta.ActiveWorkflowAssignment == nil ||
+		meta.ActiveWorkflowAssignment.SourcePath == nil ||
+		*meta.ActiveWorkflowAssignment.SourcePath != sourcePath {
+		t.Fatalf("migrated active workflow assignment = %+v", meta.ActiveWorkflowAssignment)
+	}
+}
+
+func TestEnsureActiveWorkflowAssignmentProjectionMigratesAbsentAssignment(t *testing.T) {
+	store := newSessionTestLazyStore(t)
+	if err := store.EnsureDurable(); err != nil {
+		t.Fatalf("ensure durable Session: %v", err)
+	}
+	if err := store.mutateAndPersist(func() error {
+		store.meta.ActiveWorkflowAssignmentKnown = false
+		return nil
+	}); err != nil {
+		t.Fatalf("simulate pre-projection empty Session: %v", err)
+	}
+
+	if err := store.EnsureActiveWorkflowAssignmentProjection(); err != nil {
+		t.Fatalf("migrate absent workflow assignment projection: %v", err)
+	}
+	meta := store.Meta()
+	if !meta.ActiveWorkflowAssignmentKnown || meta.ActiveWorkflowAssignment != nil {
+		t.Fatalf("migrated absent workflow assignment state = known %v assignment %+v", meta.ActiveWorkflowAssignmentKnown, meta.ActiveWorkflowAssignment)
+	}
+}
+
+func TestEnsureActiveWorkflowAssignmentProjectionDoesNotScanPastBoundedWindow(t *testing.T) {
+	store := newSessionTestLazyStore(t)
+	if err := store.EnsureDurable(); err != nil {
+		t.Fatalf("ensure durable Session: %v", err)
+	}
+	eventLog, err := store.MaterializeEventLog()
+	if err != nil {
+		t.Fatalf("materialize event log: %v", err)
+	}
+	payloads := make([]EventRecordPayload, activeWorkflowAssignmentMigrationWindow+1)
+	for index := range payloads {
+		content := fmt.Sprintf("ordinary message %d", index)
+		payloads[index] = MessageRecord{Role: MessageRoleUser, Content: &content}
+	}
+	if _, receipt, err := eventLog.AppendRecordsAtomic(nil, payloads); err != nil || !receipt.Committed {
+		t.Fatalf("append migration-window fixture = %+v, %v", receipt, err)
+	}
+	if err := store.mutateAndPersist(func() error {
+		store.meta.ActiveWorkflowAssignmentKnown = false
+		return nil
+	}); err != nil {
+		t.Fatalf("simulate unresolved pre-projection Session: %v", err)
+	}
+
+	err = store.EnsureActiveWorkflowAssignmentProjection()
+	if !errors.Is(err, ErrActiveWorkflowAssignmentProjectionUnavailable) {
+		t.Fatalf("projection migration error = %v, want bounded-window unavailable", err)
+	}
+}

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -242,9 +242,9 @@ func (s *Starter) prepareCurrentNodeAgentAssignment(
 }
 
 type manualMoveAssignmentRestoration struct {
-	currentContext *workflowstore.CurrentNodeStartContext
-	projectID      string
-	snapshot       *runtime.WorkflowAssignmentSnapshot
+	projectID           string
+	snapshot            runtime.WorkflowAssignmentSnapshot
+	assignmentCommitted bool
 }
 
 func (s *Starter) PrepareManualMoveAssignments(
@@ -266,25 +266,15 @@ func (s *Starter) PrepareManualMoveAssignments(
 			}
 		}
 		for sessionID, restoration := range restorations {
-			switch {
-			case restoration.currentContext != nil:
-				cause = errors.Join(cause, s.restoreManualMoveOriginAssignment(ctx, *restoration.currentContext))
-			case restoration.snapshot != nil:
-				cause = errors.Join(cause, s.restoreManualMoveAssignmentSnapshot(
-					ctx,
-					restoration.projectID,
-					sessionID,
-					*restoration.snapshot,
-				))
-			default:
-				cause = errors.Join(cause, errors.New("manual move assignment restoration is invalid"))
-			}
+			cause = errors.Join(cause, s.restoreManualMoveAssignmentSnapshot(
+				ctx,
+				restoration.projectID,
+				sessionID,
+				restoration.snapshot,
+				restoration.assignmentCommitted,
+			))
 		}
 		return cause
-	}
-	originBySession, err := s.manualMoveOriginContextsBySession(ctx, inputs)
-	if err != nil {
-		return workflowstore.ManualMoveTargetAssignmentPreparation{}, nil, err
 	}
 	for _, input := range inputs {
 		requiresAssignment := input.CurrentNode.AgentExecutionSelection != nil
@@ -302,8 +292,7 @@ func (s *Starter) PrepareManualMoveAssignments(
 			if policyErr != nil {
 				return workflowstore.ManualMoveTargetAssignmentPreparation{}, nil, cleanupPrepared(policyErr)
 			}
-			_, currentOrigin := originBySession[*input.CurrentNode.SessionID]
-			if !policy.cloneRetainedSession && !currentOrigin {
+			if !policy.cloneRetainedSession {
 				snapshot, found, snapshotErr := s.captureManualMoveAssignmentSnapshot(
 					ctx,
 					input.Task.ProjectID,
@@ -318,6 +307,10 @@ func (s *Starter) PrepareManualMoveAssignments(
 					)
 				}
 				priorAssignment = &snapshot
+				restorations[*input.CurrentNode.SessionID] = manualMoveAssignmentRestoration{
+					projectID: input.Task.ProjectID,
+					snapshot:  snapshot,
+				}
 			}
 		}
 		key, err := input.CurrentNode.Reference.Key()
@@ -344,16 +337,15 @@ func (s *Starter) PrepareManualMoveAssignments(
 			CurrentNode: input.CurrentNode.Reference,
 			SessionID:   assignment.SessionID(),
 		})
-		if origin, exists := originBySession[assignment.SessionID()]; exists {
-			originCopy := origin
-			restorations[assignment.SessionID()] = manualMoveAssignmentRestoration{currentContext: &originCopy}
-		} else if priorAssignment != nil &&
-			input.CurrentNode.SessionID != nil &&
-			assignment.SessionID() == *input.CurrentNode.SessionID {
-			restorations[assignment.SessionID()] = manualMoveAssignmentRestoration{
-				projectID: input.Task.ProjectID,
-				snapshot:  priorAssignment,
+		if priorAssignment != nil {
+			restoration, exists := restorations[assignment.SessionID()]
+			if !exists {
+				return workflowstore.ManualMoveTargetAssignmentPreparation{}, nil, cleanupPrepared(
+					fmt.Errorf("retained Session %q assignment identity changed during preparation", assignment.SessionID()),
+				)
 			}
+			restoration.assignmentCommitted = true
+			restorations[assignment.SessionID()] = restoration
 		}
 	}
 	return workflowstore.ManualMoveTargetAssignmentPreparation{
@@ -361,55 +353,6 @@ func (s *Starter) PrepareManualMoveAssignments(
 		Diagnostic:  errors.Join(diagnostics...),
 		Abort:       cleanupPrepared,
 	}, steers, nil
-}
-
-func (s *Starter) manualMoveOriginContextsBySession(
-	ctx context.Context,
-	inputs []workflowstore.CurrentNodeStartContext,
-) (map[runtimeids.SessionID]workflowstore.CurrentNodeStartContext, error) {
-	result := make(map[runtimeids.SessionID]workflowstore.CurrentNodeStartContext)
-	if len(inputs) == 0 {
-		return result, nil
-	}
-	currentNodes, err := s.store.ListCurrentNodes(ctx, inputs[0].Task.ID)
-	if err != nil {
-		return nil, err
-	}
-	for _, currentNode := range currentNodes {
-		if currentNode.SessionID == nil {
-			continue
-		}
-		input, err := s.store.ResolveCurrentNodeStartContext(ctx, currentNode.Reference)
-		if err != nil {
-			return nil, err
-		}
-		if input.Node.Kind == workflow.NodeKindAgent {
-			result[*currentNode.SessionID] = input
-		}
-	}
-	return result, nil
-}
-
-func (s *Starter) restoreManualMoveOriginAssignment(
-	ctx context.Context,
-	input workflowstore.CurrentNodeStartContext,
-) error {
-	restoreCtx := context.WithoutCancel(ctx)
-	prepared, err := s.prepareCurrentNodeAgentAssignment(restoreCtx, input, false)
-	if err != nil {
-		return fmt.Errorf("restore Manual Move origin %v assignment: %w", input.CurrentNode.Reference, err)
-	}
-	receipt, waitErr := prepared.Wait(restoreCtx)
-	if !receipt.Committed {
-		if assignment, ok := prepared.(*currentNodeAgentAssignmentSteer); ok {
-			waitErr = assignment.cleanupUncommitted(waitErr)
-		}
-		return errors.Join(
-			fmt.Errorf("restore Manual Move origin %v assignment was not committed", input.CurrentNode.Reference),
-			waitErr,
-		)
-	}
-	return waitErr
 }
 
 func (s *Starter) captureManualMoveAssignmentSnapshot(
@@ -454,8 +397,22 @@ func (s *Starter) restoreManualMoveAssignmentSnapshot(
 	projectID string,
 	sessionID runtimeids.SessionID,
 	snapshot runtime.WorkflowAssignmentSnapshot,
+	assignmentCommitted bool,
 ) error {
 	restoreCtx := context.WithoutCancel(ctx)
+	if !assignmentCommitted {
+		runtimeErr := s.runtimeAuthority.WithCurrentRuntime(
+			restoreCtx,
+			sessionID,
+			func(_ context.Context, engine *runtime.Engine) error {
+				return engine.RestoreWorkflowAssignmentSnapshotThinking(snapshot)
+			},
+		)
+		if runtimeErr != nil && !errors.Is(runtimeErr, serverapi.ErrRuntimeUnavailable) {
+			return fmt.Errorf("restore Manual Move Session %q thinking: %w", sessionID, runtimeErr)
+		}
+		return nil
+	}
 	descriptor, err := session.NewScopedOpenSessionDescriptor(
 		sessionID,
 		filepath.Join(s.cfg.PersistenceRoot, "projects", projectID, "sessions"),


### PR DESCRIPTION
## Summary
- initialize the active Workflow assignment projection for pre-projection Sessions from a bounded recent-record window
- fail safely when the bounded migration cannot establish prior assignment state
- restore live thinking on every retained Manual Move preparation failure
- append the prior assignment only when the replacement assignment committed

## Verification
- focused Session projection, Runtime assignment snapshot, and Manual Move integration tests pass
- affected test run passed relevant packages; unrelated PTY fixture timed out in `live_background_shell_completion_style`