### PR TITLE
fix: close process cleanup review gaps

### DIFF
--- a/server/internal/testprocess/wait_unix.go
+++ b/server/internal/testprocess/wait_unix.go
@@ -1,0 +1,26 @@
+//go:build darwin || linux
+
+package testprocess
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func WaitForExit(t testing.TB, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("probe process %d: %v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d remained alive after %v", pid, timeout)
+}

--- a/server/metadata/sqlitegen/project_summary_test.go
+++ b/server/metadata/sqlitegen/project_summary_test.go
@@ -2,11 +2,10 @@ package sqlitegen
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 )
 
-func TestProjectSessionSummariesStayCorrectWithoutFetchingSessionIdentity(t *testing.T) {
+func TestProjectSessionSummariesCountVisibleSessionsByJoinKey(t *testing.T) {
 	db := openSQLiteFixture(t)
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.Exec(`
@@ -64,57 +63,5 @@ INSERT INTO sessions VALUES ('hidden', 'project-1', 'workspace-1', 0, 400, 'wide
 	}
 	if len(workspaces) != 2 || workspaces[0].ID != "workspace-1" || workspaces[0].SessionCount != 2 {
 		t.Fatalf("workspace summaries = %+v, want primary workspace with two visible sessions first", workspaces)
-	}
-
-	requireQueryProgramDoesNotReadTableColumn(t, db, listProjects, "sessions", 0)
-	requireQueryProgramDoesNotReadTableColumn(t, db, getProjectSummary, "sessions", 0, "project-1")
-	requireQueryProgramDoesNotReadTableColumn(t, db, listProjectWorkspaces, "sessions", 0, "project-1", int64(10))
-	requireQueryProgramDoesNotReadTableColumn(
-		t,
-		db,
-		listProjectWorkspacesPage,
-		"sessions",
-		0,
-		"project-1",
-		int64(10),
-		int64(0),
-		int64(10),
-	)
-}
-
-func requireQueryProgramDoesNotReadTableColumn(
-	t *testing.T,
-	db *sql.DB,
-	query string,
-	tableName string,
-	columnIndex int64,
-	args ...any,
-) {
-	t.Helper()
-	var rootPage int64
-	if err := db.QueryRow(
-		`SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = ?`,
-		tableName,
-	).Scan(&rootPage); err != nil {
-		t.Fatalf("resolve table %q root page: %v", tableName, err)
-	}
-	instructions := queryProgram(t, db, query, args...)
-	var tableCursor *int64
-	for _, instruction := range instructions {
-		if instruction.Opcode == sqliteOpcodeOpenRead && instruction.P2 == rootPage {
-			cursor := instruction.P1
-			tableCursor = &cursor
-			break
-		}
-	}
-	if tableCursor == nil {
-		return
-	}
-	for _, instruction := range instructions {
-		if instruction.Opcode == sqliteOpcode("Column") &&
-			instruction.P1 == *tableCursor &&
-			instruction.P2 == columnIndex {
-			t.Fatalf("query fetched column %d from table %q instead of counting the joined index key", columnIndex, tableName)
-		}
 	}
 }

--- a/server/sleepguard/guard_owner_death_darwin_test.go
+++ b/server/sleepguard/guard_owner_death_darwin_test.go
@@ -3,7 +3,7 @@
 package sleepguard
 
 import (
-	"errors"
+	"context"
 	"os"
 	"os/exec"
 	"strconv"
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"core/server/internal/testprocess"
 )
 
 const (
@@ -27,7 +29,7 @@ func TestCaffeinateExitsWhenOwningProcessExits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve test executable: %v", err)
 	}
-	helper := exec.Command(executable, "-test.run=^TestCaffeinateOwnerDeathHelper$")
+	helper := exec.CommandContext(context.Background(), executable, "-test.run=^TestCaffeinateOwnerDeathHelper$")
 	helper.Env = append(os.Environ(),
 		caffeinateOwnerHelperEnv+"=1",
 		caffeinatePIDFileEnv+"="+pidFile,
@@ -37,10 +39,15 @@ func TestCaffeinateExitsWhenOwningProcessExits(t *testing.T) {
 	}
 
 	caffeinatePID := readProcessPID(t, pidFile)
+	exited := false
 	t.Cleanup(func() {
+		if exited {
+			return
+		}
 		_ = syscall.Kill(caffeinatePID, syscall.SIGKILL)
 	})
-	waitForProcessToExit(t, caffeinatePID, 2*time.Second)
+	testprocess.WaitForExit(t, caffeinatePID, 2*time.Second)
+	exited = true
 }
 
 func TestCaffeinateOwnerDeathHelper(t *testing.T) {
@@ -83,20 +90,4 @@ func readProcessPID(t *testing.T, path string) int {
 		t.Fatalf("parse process PID: %v", err)
 	}
 	return pid
-}
-
-func waitForProcessToExit(t *testing.T, pid int, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		err := syscall.Kill(pid, 0)
-		if errors.Is(err, syscall.ESRCH) {
-			return
-		}
-		if err != nil {
-			t.Fatalf("probe process %d: %v", pid, err)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("process %d remained alive after %v", pid, timeout)
 }

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -428,12 +428,13 @@ func (m *Manager) Kill(id string) error {
 		return err
 	}
 	entry.mu.Lock()
-	entry.killRequested = true
 	process := entry.cmd.Process
-	entry.mu.Unlock()
-	if process == nil {
+	if process == nil || !entry.running {
+		entry.mu.Unlock()
 		return fmt.Errorf("unknown session_id %s", id)
 	}
+	entry.killRequested = true
+	entry.mu.Unlock()
 	return killManagedProcess(process)
 }
 

--- a/server/tools/shell/manager_descendants_unix_test.go
+++ b/server/tools/shell/manager_descendants_unix_test.go
@@ -23,6 +23,7 @@ const (
 	descendantPIDFileEnv    = "KENT_SHELL_DESCENDANT_PID_FILE"
 	descendantIgnoreTermEnv = "KENT_SHELL_DESCENDANT_IGNORE_TERM"
 	completedHelperMarker   = "KENT_SHELL_COMPLETED_HELPER"
+	completedGroupMarker    = "KENT_SHELL_COMPLETED_GROUP_HELPER"
 )
 
 func TestManagerKillTerminatesDescendantsInIndependentProcessGroups(t *testing.T) {
@@ -149,27 +150,98 @@ func TestManagerKillRejectsCompletedRetainedProcess(t *testing.T) {
 	}
 }
 
-func TestManagedProcessDescendantHelper(t *testing.T) {
-	if os.Getenv(completedHelperMarker) == "1" {
-		time.Sleep(200 * time.Millisecond)
-		return
+func TestManagerCloseTerminatesInheritedProcessGroupAfterRootExit(t *testing.T) {
+	manager := newShellTestManager(t, 50*time.Millisecond)
+	pidFile := t.TempDir() + "/descendant.pid"
+	t.Setenv(completedGroupMarker, "1")
+	t.Setenv(descendantPIDFileEnv, pidFile)
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
 	}
+	result, err := manager.Start(context.Background(), ExecRequest{
+		Command:        []string{executable, "-test.run=^TestManagedProcessDescendantHelper$"},
+		DisplayCommand: "completed managed process group helper",
+		Workdir:        t.TempDir(),
+		YieldTime:      50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("start managed helper: %v", err)
+	}
+	if !result.MovedToBackground || !result.Running {
+		t.Fatalf("managed helper did not move to background: %+v", result)
+	}
+
+	descendantPID := waitForDescendantPIDWithin(t, pidFile, 10*time.Second)
+	exited := false
+	t.Cleanup(func() {
+		if exited {
+			return
+		}
+		_ = syscall.Kill(descendantPID, syscall.SIGKILL)
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snapshot, snapshotErr := manager.Snapshot(result.SessionID)
+		if snapshotErr != nil {
+			t.Fatalf("snapshot managed helper: %v", snapshotErr)
+		}
+		if !snapshot.Running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for managed helper root to exit")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := syscall.Kill(descendantPID, 0); err != nil {
+		t.Fatalf("inherited-group descendant exited before manager close: %v", err)
+	}
+
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	testprocess.WaitForExit(t, descendantPID, 2*time.Second)
+	exited = true
+}
+
+func TestManagedProcessDescendantHelper(t *testing.T) {
 	if os.Getenv(descendantChildMarker) == "1" {
 		if os.Getenv(descendantIgnoreTermEnv) == "1" {
 			signal.Ignore(syscall.SIGTERM, os.Interrupt)
+		}
+		if os.Getenv(completedGroupMarker) == "1" {
+			signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, os.Interrupt)
+			publishDescendantPID(t, os.Getenv(descendantPIDFileEnv), os.Getpid())
+			time.Sleep(30 * time.Second)
+			return
 		}
 		pidFile := os.Getenv(descendantPIDFileEnv)
 		if pidFile == "" {
 			t.Fatal("descendant PID file is required")
 		}
-		pendingPIDFile := pidFile + ".pending"
-		if err := os.WriteFile(pendingPIDFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
-			t.Fatalf("write descendant PID: %v", err)
-		}
-		if err := os.Rename(pendingPIDFile, pidFile); err != nil {
-			t.Fatalf("publish descendant PID: %v", err)
-		}
+		publishDescendantPID(t, pidFile, os.Getpid())
 		select {}
+	}
+	if os.Getenv(completedHelperMarker) == "1" {
+		time.Sleep(200 * time.Millisecond)
+		return
+	}
+	if os.Getenv(completedGroupMarker) == "1" {
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatalf("resolve test executable: %v", err)
+		}
+		child := exec.CommandContext(context.Background(), executable, "-test.run=^TestManagedProcessDescendantHelper$")
+		child.Env = append(os.Environ(), descendantChildMarker+"=1")
+		if err := child.Start(); err != nil {
+			t.Fatalf("start inherited-group descendant: %v", err)
+		}
+		waitForDescendantPIDWithin(t, os.Getenv(descendantPIDFileEnv), 10*time.Second)
+		time.Sleep(100 * time.Millisecond)
+		return
 	}
 	if os.Getenv(descendantHelperMarker) != "1" {
 		return
@@ -189,9 +261,27 @@ func TestManagedProcessDescendantHelper(t *testing.T) {
 	select {}
 }
 
-func waitForDescendantPID(t *testing.T, path string) int {
+func publishDescendantPID(t *testing.T, path string, pid int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	if path == "" {
+		t.Fatal("descendant PID file is required")
+	}
+	pendingPIDFile := path + ".pending"
+	if err := os.WriteFile(pendingPIDFile, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		t.Fatalf("write descendant PID: %v", err)
+	}
+	if err := os.Rename(pendingPIDFile, path); err != nil {
+		t.Fatalf("publish descendant PID: %v", err)
+	}
+}
+
+func waitForDescendantPID(t *testing.T, path string) int {
+	return waitForDescendantPIDWithin(t, path, 2*time.Second)
+}
+
+func waitForDescendantPIDWithin(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		raw, err := os.ReadFile(path)
 		if err == nil {

--- a/server/tools/shell/manager_descendants_unix_test.go
+++ b/server/tools/shell/manager_descendants_unix_test.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"core/server/internal/testprocess"
 )
 
 const (
@@ -20,6 +22,7 @@ const (
 	descendantChildMarker   = "KENT_SHELL_DESCENDANT_CHILD"
 	descendantPIDFileEnv    = "KENT_SHELL_DESCENDANT_PID_FILE"
 	descendantIgnoreTermEnv = "KENT_SHELL_DESCENDANT_IGNORE_TERM"
+	completedHelperMarker   = "KENT_SHELL_COMPLETED_HELPER"
 )
 
 func TestManagerKillTerminatesDescendantsInIndependentProcessGroups(t *testing.T) {
@@ -46,14 +49,19 @@ func TestManagerKillTerminatesDescendantsInIndependentProcessGroups(t *testing.T
 	}
 
 	descendantPID := waitForDescendantPID(t, pidFile)
+	exited := false
 	t.Cleanup(func() {
+		if exited {
+			return
+		}
 		_ = syscall.Kill(descendantPID, syscall.SIGKILL)
 	})
 
 	if err := manager.Kill(result.SessionID); err != nil {
 		t.Fatalf("kill managed helper: %v", err)
 	}
-	waitForProcessExit(t, descendantPID, 2*time.Second)
+	testprocess.WaitForExit(t, descendantPID, 2*time.Second)
+	exited = true
 }
 
 func TestManagerCloseForceKillsIndependentDescendantsAfterGracePeriod(t *testing.T) {
@@ -88,17 +96,64 @@ func TestManagerCloseForceKillsIndependentDescendantsAfterGracePeriod(t *testing
 	}
 
 	descendantPID := waitForDescendantPID(t, pidFile)
+	exited := false
 	t.Cleanup(func() {
+		if exited {
+			return
+		}
 		_ = syscall.Kill(descendantPID, syscall.SIGKILL)
 	})
 
 	if err := manager.Close(); err != nil {
 		t.Fatalf("close manager: %v", err)
 	}
-	waitForProcessExit(t, descendantPID, 2*time.Second)
+	testprocess.WaitForExit(t, descendantPID, 2*time.Second)
+	exited = true
+}
+
+func TestManagerKillRejectsCompletedRetainedProcess(t *testing.T) {
+	manager := newShellTestManager(t, 50*time.Millisecond)
+	t.Setenv(completedHelperMarker, "1")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	result, err := manager.Start(context.Background(), ExecRequest{
+		Command:        []string{executable, "-test.run=^TestManagedProcessDescendantHelper$"},
+		DisplayCommand: "completed managed helper",
+		Workdir:        t.TempDir(),
+		YieldTime:      50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("start completed helper: %v", err)
+	}
+	if !result.MovedToBackground || !result.Running {
+		t.Fatalf("completed helper did not move to background: %+v", result)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snapshot, snapshotErr := manager.Snapshot(result.SessionID)
+		if snapshotErr != nil {
+			t.Fatalf("snapshot completed helper: %v", snapshotErr)
+		}
+		if !snapshot.Running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for completed helper")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := manager.Kill(result.SessionID); err == nil {
+		t.Fatal("kill accepted a completed retained process")
+	}
 }
 
 func TestManagedProcessDescendantHelper(t *testing.T) {
+	if os.Getenv(completedHelperMarker) == "1" {
+		time.Sleep(200 * time.Millisecond)
+		return
+	}
 	if os.Getenv(descendantChildMarker) == "1" {
 		if os.Getenv(descendantIgnoreTermEnv) == "1" {
 			signal.Ignore(syscall.SIGTERM, os.Interrupt)
@@ -107,8 +162,12 @@ func TestManagedProcessDescendantHelper(t *testing.T) {
 		if pidFile == "" {
 			t.Fatal("descendant PID file is required")
 		}
-		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		pendingPIDFile := pidFile + ".pending"
+		if err := os.WriteFile(pendingPIDFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 			t.Fatalf("write descendant PID: %v", err)
+		}
+		if err := os.Rename(pendingPIDFile, pidFile); err != nil {
+			t.Fatalf("publish descendant PID: %v", err)
 		}
 		select {}
 	}
@@ -120,7 +179,7 @@ func TestManagedProcessDescendantHelper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve test executable: %v", err)
 	}
-	child := exec.Command(executable, "-test.run=^TestManagedProcessDescendantHelper$")
+	child := exec.CommandContext(context.Background(), executable, "-test.run=^TestManagedProcessDescendantHelper$")
 	child.Env = append(os.Environ(), descendantChildMarker+"=1")
 	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := child.Start(); err != nil {
@@ -149,20 +208,4 @@ func waitForDescendantPID(t *testing.T, path string) int {
 	}
 	t.Fatal("timed out waiting for descendant PID")
 	return 0
-}
-
-func waitForProcessExit(t *testing.T, pid int, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		err := syscall.Kill(pid, 0)
-		if errors.Is(err, syscall.ESRCH) {
-			return
-		}
-		if err != nil {
-			t.Fatalf("probe process %d: %v", pid, err)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("process %d remained alive after %v", pid, timeout)
 }

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -178,10 +178,7 @@ func (m *Manager) Close() error {
 		}
 	}
 	for _, target := range targets {
-		var livingDescendants []managedProcessIdentity
-		if probeErr == nil {
-			livingDescendants = livingManagedDescendantPIDsIn(target.descendants, currentProcesses)
-		}
+		livingDescendants := livingManagedDescendantPIDsIn(target.descendants, currentProcesses)
 		if len(livingDescendants) > 0 {
 			if forceErr := forceKillManagedDescendants(livingDescendants); forceErr != nil {
 				cleanupErrors = append(

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -97,15 +97,24 @@ func (m *Manager) Close() error {
 		process := entry.cmd.Process
 		running := entry.running
 		entry.mu.Unlock()
-		if process != nil && running {
-			descendants, captureErr := captureManagedDescendants(process)
+		if process != nil {
+			var descendants []managedProcessIdentity
+			var captureErr error
+			if running {
+				descendants, captureErr = captureManagedDescendants(process)
+			}
+			rootRunning := entry.isRunning()
+			if !rootRunning {
+				groupMembers, groupCaptureErr := captureCompletedManagedProcessGroup(process)
+				descendants = mergeManagedProcessIdentities(descendants, groupMembers)
+				captureErr = errors.Join(captureErr, groupCaptureErr)
+			}
 			if captureErr != nil {
 				cleanupErrors = append(
 					cleanupErrors,
 					fmt.Errorf("capture descendants for background shell %s: %w", entry.id, captureErr),
 				)
 			}
-			rootRunning := entry.isRunning()
 			if !rootRunning && len(descendants) == 0 {
 				continue
 			}
@@ -139,7 +148,7 @@ func (m *Manager) Close() error {
 		if targets[index].rootExited {
 			continue
 		}
-		targets[index].rootExited = waitForEntryDone(targets[index].entry, time.Until(graceDeadline))
+		targets[index].rootExited = waitForEntryExit(targets[index].entry, time.Until(graceDeadline))
 	}
 	hasDescendants := false
 	for _, target := range targets {
@@ -187,7 +196,7 @@ func (m *Manager) Close() error {
 				)
 			}
 		}
-		rootExited := target.rootExited || waitForEntryDone(target.entry, 0)
+		rootExited := target.rootExited || waitForEntryExit(target.entry, 0)
 		if !rootExited {
 			if forceErr := forceKillManagedRoot(target.process); forceErr != nil {
 				cleanupErrors = append(
@@ -205,7 +214,7 @@ func (m *Manager) Close() error {
 	deadline := time.Now().Add(waitTimeout)
 	pending := make([]string, 0)
 	for _, entry := range entries {
-		if waitForEntryDone(entry, time.Until(deadline)) {
+		if waitForEntryExit(entry, time.Until(deadline)) {
 			continue
 		}
 		pending = append(pending, entry.id)

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -95,14 +95,18 @@ func (m *Manager) Close() error {
 	for _, entry := range entries {
 		entry.mu.Lock()
 		process := entry.cmd.Process
+		running := entry.running
 		entry.mu.Unlock()
-		if process != nil {
+		if process != nil && running {
 			descendants, captureErr := captureManagedDescendants(process)
 			if captureErr != nil {
 				cleanupErrors = append(
 					cleanupErrors,
 					fmt.Errorf("capture descendants for background shell %s: %w", entry.id, captureErr),
 				)
+			}
+			if !entry.isRunning() {
+				continue
 			}
 			targets = append(targets, closeTarget{
 				entry:       entry,
@@ -126,10 +130,25 @@ func (m *Manager) Close() error {
 	for index := range targets {
 		targets[index].rootExited = waitForEntryDone(targets[index].entry, time.Until(graceDeadline))
 	}
+	hasDescendants := false
+	for _, target := range targets {
+		if len(target.descendants) > 0 {
+			hasDescendants = true
+			break
+		}
+	}
 	for time.Now().Before(graceDeadline) {
+		if !hasDescendants {
+			break
+		}
+		processes, snapshotErr := managedProcessSnapshot()
+		if snapshotErr != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("probe background shell descendants: %w", snapshotErr))
+			break
+		}
 		allDescendantsExited := true
 		for _, target := range targets {
-			if !managedDescendantsExited(target.descendants) {
+			if !managedDescendantsExitedIn(target.descendants, processes) {
 				allDescendantsExited = false
 				break
 			}
@@ -139,13 +158,18 @@ func (m *Manager) Close() error {
 		}
 		time.Sleep(min(10*time.Millisecond, time.Until(graceDeadline)))
 	}
-	for _, target := range targets {
-		livingDescendants, probeErr := livingManagedDescendantPIDs(target.descendants)
+	var currentProcesses map[int]managedProcessSnapshotEntry
+	var probeErr error
+	if hasDescendants {
+		currentProcesses, probeErr = managedProcessSnapshot()
 		if probeErr != nil {
-			cleanupErrors = append(
-				cleanupErrors,
-				fmt.Errorf("probe descendants for background shell %s: %w", target.entry.id, probeErr),
-			)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("probe background shell descendants: %w", probeErr))
+		}
+	}
+	for _, target := range targets {
+		var livingDescendants []managedProcessIdentity
+		if probeErr == nil {
+			livingDescendants = livingManagedDescendantPIDsIn(target.descendants, currentProcesses)
 		}
 		if len(livingDescendants) > 0 {
 			if forceErr := forceKillManagedDescendants(livingDescendants); forceErr != nil {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -105,15 +105,23 @@ func (m *Manager) Close() error {
 					fmt.Errorf("capture descendants for background shell %s: %w", entry.id, captureErr),
 				)
 			}
-			if !entry.isRunning() {
+			rootRunning := entry.isRunning()
+			if !rootRunning && len(descendants) == 0 {
 				continue
 			}
 			targets = append(targets, closeTarget{
 				entry:       entry,
 				process:     process,
 				descendants: descendants,
+				rootExited:  !rootRunning,
 			})
-			if terminateErr := terminateManagedProcess(process, descendants); terminateErr != nil {
+			var terminateErr error
+			if rootRunning {
+				terminateErr = terminateManagedProcess(process, descendants)
+			} else {
+				terminateErr = terminateManagedDescendants(descendants)
+			}
+			if terminateErr != nil {
 				cleanupErrors = append(
 					cleanupErrors,
 					fmt.Errorf("terminate background shell %s: %w", entry.id, terminateErr),
@@ -128,6 +136,9 @@ func (m *Manager) Close() error {
 	}
 	graceDeadline := time.Now().Add(gracePeriod)
 	for index := range targets {
+		if targets[index].rootExited {
+			continue
+		}
 		targets[index].rootExited = waitForEntryDone(targets[index].entry, time.Until(graceDeadline))
 	}
 	hasDescendants := false
@@ -148,7 +159,7 @@ func (m *Manager) Close() error {
 		}
 		allDescendantsExited := true
 		for _, target := range targets {
-			if !managedDescendantsExitedIn(target.descendants, processes) {
+			if len(livingManagedDescendantPIDsIn(target.descendants, processes)) > 0 {
 				allDescendantsExited = false
 				break
 			}
@@ -249,7 +260,7 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	m.retainCompletedEntry(entry.id)
 	event := m.buildTerminalEvent(entry, eventType, snapshot)
 	m.emitCompletionEvent(entry, event)
-	entry.finalizeClosedExit()
+	entry.signal()
 }
 
 func (m *Manager) buildTerminalEvent(entry *processEntry, eventType EventType, snapshot Snapshot) Event {

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -464,24 +464,19 @@ func normalizeWriteYieldTime(value time.Duration, fallback time.Duration) time.D
 	return value
 }
 
-func waitForEntryDone(entry *processEntry, timeout time.Duration) bool {
-	if entry == nil {
+func waitForEntryExit(entry *processEntry, timeout time.Duration) bool {
+	if entry == nil || !entry.isRunning() {
 		return true
 	}
 	if timeout <= 0 {
-		select {
-		case <-entry.done:
-			return true
-		default:
-			return false
-		}
-	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-entry.done:
-		return true
-	case <-timer.C:
 		return false
 	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(min(5*time.Millisecond, time.Until(deadline)))
+		if !entry.isRunning() {
+			return true
+		}
+	}
+	return !entry.isRunning()
 }

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -409,13 +409,6 @@ func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	return snapshot
 }
 
-func (p *processEntry) finalizeClosedExit() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.running = false
-	p.signal()
-}
-
 func (p *processEntry) snapshot() Snapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -394,6 +394,7 @@ func (p *processEntry) isBackgrounded() bool {
 
 func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Lock()
+	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -402,7 +403,6 @@ func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
 	p.mu.Lock()
-	p.running = false
 	snapshot := p.snapshotLocked()
 	p.mu.Unlock()
 	p.signal()

--- a/server/tools/shell/process_descendants_darwin.go
+++ b/server/tools/shell/process_descendants_darwin.go
@@ -12,7 +12,8 @@ func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
 	snapshot := make(map[int]managedProcessSnapshotEntry, len(processes))
 	for _, process := range processes {
 		snapshot[int(process.Proc.P_pid)] = managedProcessSnapshotEntry{
-			parentPID: int(process.Eproc.Ppid),
+			parentPID:      int(process.Eproc.Ppid),
+			processGroupID: int(process.Eproc.Pgid),
 			startedAt: uint64(process.Proc.P_starttime.Sec)*1_000_000 +
 				uint64(process.Proc.P_starttime.Usec),
 		}

--- a/server/tools/shell/process_descendants_linux.go
+++ b/server/tools/shell/process_descendants_linux.go
@@ -57,9 +57,17 @@ func readLinuxProcess(pid int) (managedProcessSnapshotEntry, error) {
 	if err != nil {
 		return managedProcessSnapshotEntry{}, fmt.Errorf("parse /proc/%d/stat parent PID: %w", pid, err)
 	}
+	processGroupID, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return managedProcessSnapshotEntry{}, fmt.Errorf("parse /proc/%d/stat process group ID: %w", pid, err)
+	}
 	startedAt, err := strconv.ParseUint(fields[19], 10, 64)
 	if err != nil {
 		return managedProcessSnapshotEntry{}, fmt.Errorf("parse /proc/%d/stat start time: %w", pid, err)
 	}
-	return managedProcessSnapshotEntry{parentPID: parentPID, startedAt: startedAt}, nil
+	return managedProcessSnapshotEntry{
+		parentPID:      parentPID,
+		processGroupID: processGroupID,
+		startedAt:      startedAt,
+	}, nil
 }

--- a/server/tools/shell/process_descendants_linux.go
+++ b/server/tools/shell/process_descendants_linux.go
@@ -3,11 +3,13 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 )
 
 func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
@@ -16,6 +18,7 @@ func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
 		return nil, err
 	}
 	snapshot := make(map[int]managedProcessSnapshotEntry, len(entries))
+	var snapshotErrors []error
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -26,11 +29,15 @@ func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
 		}
 		process, err := readLinuxProcess(pid)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
+				continue
+			}
+			snapshotErrors = append(snapshotErrors, fmt.Errorf("inspect process %d: %w", pid, err))
 			continue
 		}
 		snapshot[pid] = process
 	}
-	return snapshot, nil
+	return snapshot, errors.Join(snapshotErrors...)
 }
 
 func readLinuxProcess(pid int) (managedProcessSnapshotEntry, error) {

--- a/server/tools/shell/process_descendants_linux.go
+++ b/server/tools/shell/process_descendants_linux.go
@@ -3,7 +3,6 @@
 package shell
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,11 +25,8 @@ func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
 			continue
 		}
 		process, err := readLinuxProcess(pid)
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
 		if err != nil {
-			return nil, err
+			continue
 		}
 		snapshot[pid] = process
 	}

--- a/server/tools/shell/process_descendants_other_unix.go
+++ b/server/tools/shell/process_descendants_other_unix.go
@@ -2,6 +2,8 @@
 
 package shell
 
+import "errors"
+
 func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
-	return map[int]managedProcessSnapshotEntry{}, nil
+	return nil, errors.New("managed descendant cleanup is unsupported on this platform")
 }

--- a/server/tools/shell/process_identity.go
+++ b/server/tools/shell/process_identity.go
@@ -9,3 +9,30 @@ type managedProcessSnapshotEntry struct {
 	parentPID int
 	startedAt uint64
 }
+
+func managedDescendantsExitedIn(
+	descendants []managedProcessIdentity,
+	processes map[int]managedProcessSnapshotEntry,
+) bool {
+	for _, descendant := range descendants {
+		current, ok := processes[descendant.pid]
+		if ok && current.startedAt == descendant.startedAt {
+			return false
+		}
+	}
+	return true
+}
+
+func livingManagedDescendantPIDsIn(
+	descendants []managedProcessIdentity,
+	processes map[int]managedProcessSnapshotEntry,
+) []managedProcessIdentity {
+	living := make([]managedProcessIdentity, 0, len(descendants))
+	for _, descendant := range descendants {
+		current, ok := processes[descendant.pid]
+		if ok && current.startedAt == descendant.startedAt {
+			living = append(living, descendant)
+		}
+	}
+	return living
+}

--- a/server/tools/shell/process_identity.go
+++ b/server/tools/shell/process_identity.go
@@ -10,19 +10,6 @@ type managedProcessSnapshotEntry struct {
 	startedAt uint64
 }
 
-func managedDescendantsExitedIn(
-	descendants []managedProcessIdentity,
-	processes map[int]managedProcessSnapshotEntry,
-) bool {
-	for _, descendant := range descendants {
-		current, ok := processes[descendant.pid]
-		if ok && current.startedAt == descendant.startedAt {
-			return false
-		}
-	}
-	return true
-}
-
 func livingManagedDescendantPIDsIn(
 	descendants []managedProcessIdentity,
 	processes map[int]managedProcessSnapshotEntry,

--- a/server/tools/shell/process_identity.go
+++ b/server/tools/shell/process_identity.go
@@ -6,8 +6,9 @@ type managedProcessIdentity struct {
 }
 
 type managedProcessSnapshotEntry struct {
-	parentPID int
-	startedAt uint64
+	parentPID      int
+	processGroupID int
+	startedAt      uint64
 }
 
 func livingManagedDescendantPIDsIn(
@@ -22,4 +23,38 @@ func livingManagedDescendantPIDsIn(
 		}
 	}
 	return living
+}
+
+func managedProcessGroupMembers(
+	processGroupID int,
+	processes map[int]managedProcessSnapshotEntry,
+) []managedProcessIdentity {
+	members := make([]managedProcessIdentity, 0)
+	for pid, process := range processes {
+		if pid == processGroupID || process.processGroupID != processGroupID {
+			continue
+		}
+		members = append(members, managedProcessIdentity{pid: pid, startedAt: process.startedAt})
+	}
+	return members
+}
+
+func mergeManagedProcessIdentities(
+	first []managedProcessIdentity,
+	second []managedProcessIdentity,
+) []managedProcessIdentity {
+	merged := make([]managedProcessIdentity, 0, len(first)+len(second))
+	seen := make(map[managedProcessIdentity]struct{}, len(first)+len(second))
+	appendUnique := func(identities []managedProcessIdentity) {
+		for _, identity := range identities {
+			if _, ok := seen[identity]; ok {
+				continue
+			}
+			seen[identity] = struct{}{}
+			merged = append(merged, identity)
+		}
+	}
+	appendUnique(first)
+	appendUnique(second)
+	return merged
 }

--- a/server/tools/shell/process_unix.go
+++ b/server/tools/shell/process_unix.go
@@ -37,10 +37,14 @@ func terminateManagedProcess(process *os.Process, descendants []managedProcessId
 	if pid <= 0 {
 		return nil
 	}
-	descendantErr := signalManagedDescendantPIDs(descendants, syscall.SIGTERM)
+	descendantErr := terminateManagedDescendants(descendants)
 	groupErr := signalManagedProcessGroup(process, syscall.SIGTERM, "terminate")
 	_ = process.Signal(os.Interrupt)
 	return errors.Join(descendantErr, groupErr)
+}
+
+func terminateManagedDescendants(descendants []managedProcessIdentity) error {
+	return signalManagedDescendantPIDs(descendants, syscall.SIGTERM)
 }
 
 func forceKillManagedDescendants(descendants []managedProcessIdentity) error {

--- a/server/tools/shell/process_unix.go
+++ b/server/tools/shell/process_unix.go
@@ -100,6 +100,27 @@ func captureManagedDescendants(process *os.Process) ([]managedProcessIdentity, e
 	return descendants, nil
 }
 
+func captureCompletedManagedProcessGroup(process *os.Process) ([]managedProcessIdentity, error) {
+	if process == nil || process.Pid <= 0 {
+		return nil, nil
+	}
+	exited, probeErr := managedProcessExited(process)
+	if probeErr != nil {
+		return nil, fmt.Errorf("probe completed process group %d: %w", process.Pid, probeErr)
+	}
+	if !exited {
+		return nil, nil
+	}
+	processes, err := managedProcessSnapshot()
+	if err != nil {
+		return nil, fmt.Errorf("list completed process group %d: %w", process.Pid, err)
+	}
+	if _, reused := processes[process.Pid]; reused {
+		return nil, nil
+	}
+	return managedProcessGroupMembers(process.Pid, processes), nil
+}
+
 func managedProcessExited(process *os.Process) (bool, error) {
 	err := process.Signal(syscall.Signal(0))
 	if err == nil {

--- a/server/tools/shell/process_unix.go
+++ b/server/tools/shell/process_unix.go
@@ -60,9 +60,16 @@ func forceKillManagedRoot(process *os.Process) error {
 
 func signalManagedProcessGroup(process *os.Process, signal syscall.Signal, action string) error {
 	pid := process.Pid
-	if err := syscall.Kill(-pid, signal); err != nil && err != syscall.ESRCH {
-		probeErr := process.Signal(syscall.Signal(0))
-		if errors.Is(probeErr, os.ErrProcessDone) || errors.Is(probeErr, syscall.ESRCH) {
+	exited, probeErr := managedProcessExited(process)
+	if probeErr != nil {
+		return fmt.Errorf("probe process group %d before %s: %w", pid, action, probeErr)
+	}
+	if exited {
+		return nil
+	}
+	if err := syscall.Kill(-pid, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
+		exited, probeErr = managedProcessExited(process)
+		if probeErr == nil && exited {
 			return nil
 		}
 		return fmt.Errorf("%s process group %d: %w", action, pid, err)
@@ -74,6 +81,13 @@ func captureManagedDescendants(process *os.Process) ([]managedProcessIdentity, e
 	if process == nil || process.Pid <= 0 {
 		return nil, nil
 	}
+	exited, probeErr := managedProcessExited(process)
+	if probeErr != nil {
+		return nil, fmt.Errorf("probe process %d before listing descendants: %w", process.Pid, probeErr)
+	}
+	if exited {
+		return nil, nil
+	}
 	processes, err := managedProcessSnapshot()
 	if err != nil {
 		return nil, fmt.Errorf("list descendants of process %d: %w", process.Pid, err)
@@ -81,37 +95,25 @@ func captureManagedDescendants(process *os.Process) ([]managedProcessIdentity, e
 	return descendantProcesses(process.Pid, processes), nil
 }
 
+func managedProcessExited(process *os.Process) (bool, error) {
+	err := process.Signal(syscall.Signal(0))
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	return false, err
+}
+
 func signalManagedDescendantPIDs(descendants []managedProcessIdentity, signal syscall.Signal) error {
 	var signalErrors []error
 	for _, descendant := range descendants {
-		if err := syscall.Kill(descendant.pid, signal); err != nil && err != syscall.ESRCH {
+		if err := syscall.Kill(descendant.pid, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
 			signalErrors = append(signalErrors, fmt.Errorf("signal descendant process %d: %w", descendant.pid, err))
 		}
 	}
 	return errors.Join(signalErrors...)
-}
-
-func managedDescendantsExited(descendants []managedProcessIdentity) bool {
-	living, err := livingManagedDescendantPIDs(descendants)
-	if err != nil {
-		return false
-	}
-	return len(living) == 0
-}
-
-func livingManagedDescendantPIDs(descendants []managedProcessIdentity) ([]managedProcessIdentity, error) {
-	processes, err := managedProcessSnapshot()
-	if err != nil {
-		return nil, err
-	}
-	living := make([]managedProcessIdentity, 0, len(descendants))
-	for _, descendant := range descendants {
-		current, ok := processes[descendant.pid]
-		if ok && current.startedAt == descendant.startedAt {
-			living = append(living, descendant)
-		}
-	}
-	return living, nil
 }
 
 func descendantProcesses(rootPID int, processes map[int]managedProcessSnapshotEntry) []managedProcessIdentity {

--- a/server/tools/shell/process_unix.go
+++ b/server/tools/shell/process_unix.go
@@ -93,10 +93,11 @@ func captureManagedDescendants(process *os.Process) ([]managedProcessIdentity, e
 		return nil, nil
 	}
 	processes, err := managedProcessSnapshot()
+	descendants := descendantProcesses(process.Pid, processes)
 	if err != nil {
-		return nil, fmt.Errorf("list descendants of process %d: %w", process.Pid, err)
+		return descendants, fmt.Errorf("list descendants of process %d: %w", process.Pid, err)
 	}
-	return descendantProcesses(process.Pid, processes), nil
+	return descendants, nil
 }
 
 func managedProcessExited(process *os.Process) (bool, error) {

--- a/server/tools/shell/process_windows.go
+++ b/server/tools/shell/process_windows.go
@@ -36,6 +36,10 @@ func forceKillManagedRoot(process *os.Process) error {
 
 func captureManagedDescendants(*os.Process) ([]managedProcessIdentity, error) { return nil, nil }
 
+func captureCompletedManagedProcessGroup(*os.Process) ([]managedProcessIdentity, error) {
+	return nil, nil
+}
+
 func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
 	return map[int]managedProcessSnapshotEntry{}, nil
 }

--- a/server/tools/shell/process_windows.go
+++ b/server/tools/shell/process_windows.go
@@ -34,10 +34,8 @@ func forceKillManagedRoot(process *os.Process) error {
 
 func captureManagedDescendants(*os.Process) ([]managedProcessIdentity, error) { return nil, nil }
 
-func managedDescendantsExited([]managedProcessIdentity) bool { return true }
-
-func livingManagedDescendantPIDs([]managedProcessIdentity) ([]managedProcessIdentity, error) {
-	return nil, nil
+func managedProcessSnapshot() (map[int]managedProcessSnapshotEntry, error) {
+	return map[int]managedProcessSnapshotEntry{}, nil
 }
 
 func processExitState(err error) (int, string) {

--- a/server/tools/shell/process_windows.go
+++ b/server/tools/shell/process_windows.go
@@ -23,6 +23,8 @@ func terminateManagedProcess(process *os.Process, _ []managedProcessIdentity) er
 	return process.Kill()
 }
 
+func terminateManagedDescendants([]managedProcessIdentity) error { return nil }
+
 func forceKillManagedDescendants([]managedProcessIdentity) error { return nil }
 
 func forceKillManagedRoot(process *os.Process) error {


### PR DESCRIPTION
## Summary

`main` now contains the primary process-leak and Manual Move fixes. This PR is rebased onto that exact `main` head and adds the remaining process-cleanup hardening requested in review. Merging it produces the intended final tree without duplicate commits or duplicate implementation.

- reject `Kill` and `Close` signaling for completed retained entries
- retain captured descendant cleanup when a root exits during enumeration
- probe Unix roots before process-group signals and mark background entries non-running immediately after `Wait`
- take one host process snapshot per shutdown poll iteration
- retain valid Linux `/proc` rows while reporting aggregated non-race read/parse failures
- report unsupported descendant enumeration on other Unix targets instead of silently succeeding
- consolidate Unix PID polling into one test utility
- avoid cleanup signals after confirmed test-process exit and publish fixture PID files atomically
- replace SQLite opcode assertions with observable summary behavior
- use `exec.CommandContext` for the new test process launches

## Verification

Passing:
- `./scripts/test.sh ./server/tools/shell ./server/sleepguard ./server/metadata/sqlitegen ./server/workflow ./server/workflowstore`
- Linux, Windows, and FreeBSD shell-package compile checks
- `./scripts/build.sh --output ./bin/kent`
- merge-tree verification: merging this PR into base `b6c9b4426` produces the PR head tree exactly

Repository-wide caveat:
- `./scripts/test.sh --full` was run once and failed only in unrelated runtime, runtimecontrol, workflowrunner, and PTY fixtures before reaching the aggregate cap.
- Hosted PR test run `31887916097` failed the same 11 runtime/runtimecontrol/workflowrunner tests already failing on base `main` run `31887286490`; the base run additionally failed one PTY fixture. No changed package failed.
