### PR TITLE
fix: serialize question cancellation before interrupt

### DIFF
--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -31,10 +31,18 @@ type transcriptPromptKey struct {
 	promptID  clientui.PromptID
 }
 
+type promptAnswerDeliveryContinuation uint8
+
+const (
+	promptAnswerDeliveryContinuationNone promptAnswerDeliveryContinuation = iota
+	promptAnswerDeliveryContinuationRuntimeCtrlC
+)
+
 type activePromptAnswerDelivery struct {
-	key        transcriptPromptKey
-	generation uint64
-	cancel     context.CancelFunc
+	key          transcriptPromptKey
+	generation   uint64
+	cancel       context.CancelFunc
+	continuation promptAnswerDeliveryContinuation
 }
 
 type promptAnswerDeliveryResultMsg struct {
@@ -42,6 +50,8 @@ type promptAnswerDeliveryResultMsg struct {
 	generation uint64
 	err        error
 }
+
+type promptCtrlCContinuationMsg struct{}
 
 func newTranscriptPromptAnswerer(ctx context.Context, control promptBatchAnswerer) *transcriptPromptAnswerer {
 	if ctx == nil || control == nil {

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -51,7 +51,9 @@ type promptAnswerDeliveryResultMsg struct {
 	err        error
 }
 
-type promptCtrlCContinuationMsg struct{}
+type promptCtrlCContinuationMsg struct {
+	key transcriptPromptKey
+}
 
 func newTranscriptPromptAnswerer(ctx context.Context, control promptBatchAnswerer) *transcriptPromptAnswerer {
 	if ctx == nil || control == nil {

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -34,15 +34,14 @@ type transcriptPromptKey struct {
 type promptAnswerDeliveryContinuation uint8
 
 const (
-	promptAnswerDeliveryContinuationNone promptAnswerDeliveryContinuation = iota
-	promptAnswerDeliveryContinuationRuntimeCtrlC
+	promptAnswerDeliveryContinuationRuntimeCtrlC promptAnswerDeliveryContinuation = iota + 1
 )
 
 type activePromptAnswerDelivery struct {
 	key          transcriptPromptKey
 	generation   uint64
 	cancel       context.CancelFunc
-	continuation promptAnswerDeliveryContinuation
+	continuation *promptAnswerDeliveryContinuation
 }
 
 type promptAnswerDeliveryResultMsg struct {

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -255,6 +255,69 @@ func TestAskRepeatedEnterWhileDeliveryActiveDoesNotSubmitAgain(t *testing.T) {
 	}
 }
 
+func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newRecordingPromptControl()
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.setRuntimeActivityBusyForTest(true)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-interrupt-order", "Proceed?", "Yes", "No"),
+	)})
+
+	next, cancellationCommand := model.askController().handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(*uiModel)
+	activeCancellation := model.ask.activeDelivery
+	if cancellationCommand == nil || activeCancellation == nil {
+		t.Fatal("Ctrl+C did not start prompt cancellation delivery")
+	}
+	if runtimeClient.interruptCalls != 0 {
+		t.Fatal("Ctrl+C interrupted runtime before prompt cancellation completed")
+	}
+
+	next, repeatedCommand := model.askController().handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(*uiModel)
+	if repeatedCommand != nil {
+		t.Fatal("repeated Ctrl+C started another cancellation sequence")
+	}
+	if model.ask.activeDelivery != activeCancellation {
+		t.Fatal("repeated Ctrl+C replaced the in-flight prompt cancellation")
+	}
+
+	rawResult := cancellationCommand()
+	result, ok := rawResult.(promptAnswerDeliveryResultMsg)
+	if !ok {
+		t.Fatalf("prompt cancellation result = %T, want promptAnswerDeliveryResultMsg", rawResult)
+	}
+	if result.err != nil {
+		t.Fatalf("prompt cancellation failed: %v", result.err)
+	}
+	if runtimeClient.interruptCalls != 0 {
+		t.Fatal("runtime interrupted concurrently with prompt cancellation")
+	}
+
+	continuation := model.askController().applyDeliveryResult(result)
+	if continuation == nil || testActiveAsk(model) != nil {
+		t.Fatal("successful prompt cancellation did not finish the prompt and schedule global Ctrl+C")
+	}
+	next, interruptCommand := model.Update(continuation())
+	model = next.(*uiModel)
+	if interruptCommand == nil || runtimeClient.interruptCalls != 0 {
+		t.Fatal("global Ctrl+C did not defer runtime interruption to its command")
+	}
+	model = updateUIModel(t, model, interruptCommand())
+	if runtimeClient.interruptCalls != 1 {
+		t.Fatalf("runtime interrupt calls = %d, want one after prompt cancellation", runtimeClient.interruptCalls)
+	}
+
+	request := requirePromptAnswerBatchRequest(t, control)
+	entry := request.Entries[0]
+	if entry.Declined == nil {
+		t.Fatalf("prompt cancellation entry = %+v, want declined", entry)
+	}
+}
+
 func TestAskDeliverySetupFailureKeepsQuestionActivity(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	model, control := newProjectedPromptTestUIModel(t)

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -481,6 +481,63 @@ func TestPromptCtrlCContinuationWaitsForPromptActivityToClear(t *testing.T) {
 	}
 }
 
+func TestStalePromptCtrlCContinuationDoesNotClearNewerPendingContinuation(t *testing.T) {
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.sessionID = ongoingTestSessionID().String()
+	newerRunID, err := runtimeids.ParseRunID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+	if err != nil {
+		t.Fatalf("parse newer run id: %v", err)
+	}
+	newerStepID, err := runtimeids.ParseStepID("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+	if err != nil {
+		t.Fatalf("parse newer step id: %v", err)
+	}
+	newerActivity := clientui.RuntimeActivity{
+		State: clientui.RuntimeActivityAwaitingPrompt,
+		ActiveStep: &clientui.RuntimeActiveStep{
+			RunID:      newerRunID,
+			StepID:     newerStepID,
+			ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
+		},
+	}
+	if err := model.applyRuntimeActivityProjection(newerActivity); err != nil {
+		t.Fatalf("apply newer awaiting-prompt activity: %v", err)
+	}
+	newer := promptCtrlCContinuationMsg{key: transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    newerStepID,
+		promptID:  "ask-newer",
+	}}
+	stale := promptCtrlCContinuationMsg{key: transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    ongoingTestStepID(),
+		promptID:  "ask-stale",
+	}}
+
+	model = updateUIModel(t, model, newer)
+	model = updateUIModel(t, model, stale)
+
+	newerActivity.State = clientui.RuntimeActivityRunning
+	command := model.applyTranscriptRuntimeReadModelUpdate(runtimeTupleMergeResult{
+		decision: runtimeTupleApply,
+		project:  true,
+		view:     clientui.RuntimeMainView{Activity: newerActivity},
+	})
+	if command == nil {
+		t.Fatal("stale continuation cleared the newer pending Ctrl+C continuation")
+	}
+	next, interruptCommand := model.Update(command())
+	model = next.(*uiModel)
+	if interruptCommand == nil {
+		t.Fatal("newer pending continuation did not route after its prompt wait cleared")
+	}
+	model = updateUIModel(t, model, interruptCommand())
+	if runtimeClient.interruptCalls != 1 {
+		t.Fatalf("runtime interrupt calls = %d, want one for the newer continuation", runtimeClient.interruptCalls)
+	}
+}
+
 func TestAskDeliverySetupFailureKeepsQuestionActivity(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	model, control := newProjectedPromptTestUIModel(t)

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -261,6 +261,7 @@ func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) 
 	runtimeClient := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(runtimeClient)
 	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.sessionID = ongoingTestSessionID().String()
 	model.setRuntimeActivityBusyForTest(true)
 	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
 		testQuestionPrompt("ask-interrupt-order", "Proceed?", "Yes", "No"),
@@ -324,6 +325,7 @@ func TestAskCtrlCCanonicalResolutionPreservesRuntimeContinuation(t *testing.T) {
 	runtimeClient := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(runtimeClient)
 	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.sessionID = ongoingTestSessionID().String()
 	model.setRuntimeActivityBusyForTest(true)
 	prompt := testQuestionPrompt("ask-canonical-interrupt-order", "Proceed?", "Yes", "No")
 	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(prompt)})
@@ -358,6 +360,82 @@ func TestAskCtrlCCanonicalResolutionPreservesRuntimeContinuation(t *testing.T) {
 	model = updateUIModel(t, model, interruptCommand())
 	if runtimeClient.interruptCalls != 1 {
 		t.Fatalf("runtime interrupt calls = %d, want one after canonical prompt resolution", runtimeClient.interruptCalls)
+	}
+}
+
+func TestPromptCtrlCContinuationDoesNotAffectReplacementExecution(t *testing.T) {
+	replacementRunID, err := runtimeids.ParseRunID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+	if err != nil {
+		t.Fatalf("parse replacement run id: %v", err)
+	}
+	replacementStepID, err := runtimeids.ParseStepID("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+	if err != nil {
+		t.Fatalf("parse replacement step id: %v", err)
+	}
+	continuation := promptCtrlCContinuationMsg{key: transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    ongoingTestStepID(),
+		promptID:  "ask-replaced",
+	}}
+	tests := []struct {
+		name      string
+		sessionID string
+		activity  clientui.RuntimeActivity
+	}{
+		{
+			name:      "session",
+			sessionID: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+			activity:  runtimeTupleTestRunningActivity(),
+		},
+		{
+			name:      "step",
+			sessionID: ongoingTestSessionID().String(),
+			activity: clientui.RuntimeActivity{
+				State: clientui.RuntimeActivityRunning,
+				ActiveStep: &clientui.RuntimeActiveStep{
+					RunID:      replacementRunID,
+					StepID:     replacementStepID,
+					ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
+				},
+			},
+		},
+		{
+			name:      "starting",
+			sessionID: ongoingTestSessionID().String(),
+			activity:  clientui.RuntimeActivity{State: clientui.RuntimeActivityStarting},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtimeClient := &runtimeControlFakeClient{}
+			model := newProjectedTestUIModel(runtimeClient)
+			model.sessionID = test.sessionID
+			if err := model.applyRuntimeActivityProjection(test.activity); err != nil {
+				t.Fatalf("apply replacement runtime activity: %v", err)
+			}
+
+			next, command := model.Update(continuation)
+			model = next.(*uiModel)
+			if command != nil || runtimeClient.interruptCalls != 0 || model.exitAction == UIActionExit {
+				t.Fatal("stale prompt Ctrl+C continuation affected a replacement execution")
+			}
+		})
+	}
+}
+
+func TestPromptCtrlCContinuationUsesGlobalExitWhenOriginIsIdle(t *testing.T) {
+	model := newProjectedTestUIModel(&runtimeControlFakeClient{})
+	model.sessionID = ongoingTestSessionID().String()
+	model.setRuntimeActivityBusyForTest(false)
+
+	next, command := model.Update(promptCtrlCContinuationMsg{key: transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    ongoingTestStepID(),
+		promptID:  "ask-idle",
+	}})
+	model = next.(*uiModel)
+	if command == nil || model.exitAction != UIActionExit {
+		t.Fatal("idle prompt Ctrl+C continuation did not use global exit handling")
 	}
 }
 

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -439,6 +439,48 @@ func TestPromptCtrlCContinuationUsesGlobalExitWhenOriginIsIdle(t *testing.T) {
 	}
 }
 
+func TestPromptCtrlCContinuationWaitsForPromptActivityToClear(t *testing.T) {
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.sessionID = ongoingTestSessionID().String()
+	awaitingPrompt := runtimeTupleTestRunningActivity()
+	awaitingPrompt.State = clientui.RuntimeActivityAwaitingPrompt
+	if err := model.applyRuntimeActivityProjection(awaitingPrompt); err != nil {
+		t.Fatalf("apply awaiting-prompt runtime activity: %v", err)
+	}
+	continuation := promptCtrlCContinuationMsg{key: transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    ongoingTestStepID(),
+		promptID:  "ask-awaiting-runtime",
+	}}
+
+	next, command := model.Update(continuation)
+	model = next.(*uiModel)
+	if command != nil || runtimeClient.interruptCalls != 0 || model.exitAction == UIActionExit {
+		t.Fatal("awaiting-prompt continuation routed global Ctrl+C before prompt wait cleared")
+	}
+
+	command = model.applyTranscriptRuntimeReadModelUpdate(runtimeTupleMergeResult{
+		decision: runtimeTupleApply,
+		project:  true,
+		view: clientui.RuntimeMainView{
+			Activity: runtimeTupleTestRunningActivity(),
+		},
+	})
+	if command == nil {
+		t.Fatal("running activity did not release the pending prompt Ctrl+C continuation")
+	}
+	next, interruptCommand := model.Update(command())
+	model = next.(*uiModel)
+	if interruptCommand == nil || runtimeClient.interruptCalls != 0 {
+		t.Fatal("released prompt Ctrl+C continuation did not defer interruption to its command")
+	}
+	model = updateUIModel(t, model, interruptCommand())
+	if runtimeClient.interruptCalls != 1 {
+		t.Fatalf("runtime interrupt calls = %d, want one after prompt wait cleared", runtimeClient.interruptCalls)
+	}
+}
+
 func TestAskDeliverySetupFailureKeepsQuestionActivity(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	model, control := newProjectedPromptTestUIModel(t)

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"testing"
 
@@ -276,6 +277,9 @@ func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) 
 	if runtimeClient.interruptCalls != 0 {
 		t.Fatal("Ctrl+C interrupted runtime before prompt cancellation completed")
 	}
+	if model.transientStatus != "" {
+		t.Fatal("Ctrl+C reported interruption before prompt cancellation completed")
+	}
 
 	next, repeatedCommand := model.askController().handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
 	model = next.(*uiModel)
@@ -307,6 +311,9 @@ func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) 
 	if interruptCommand == nil || runtimeClient.interruptCalls != 0 {
 		t.Fatal("global Ctrl+C did not defer runtime interruption to its command")
 	}
+	if model.transientStatus == "" || model.transientStatusKind != uiStatusNoticeError {
+		t.Fatal("successful prompt cancellation did not report interruption when routing global Ctrl+C")
+	}
 	model = updateUIModel(t, model, interruptCommand())
 	if runtimeClient.interruptCalls != 1 {
 		t.Fatalf("runtime interrupt calls = %d, want one after prompt cancellation", runtimeClient.interruptCalls)
@@ -316,6 +323,35 @@ func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) 
 	entry := request.Entries[0]
 	if entry.Declined == nil {
 		t.Fatalf("prompt cancellation entry = %+v, want declined", entry)
+	}
+}
+
+func TestAskCtrlCCancellationConnectionFailureDoesNotReportInterrupted(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := &scriptedAskPromptControl{results: []error{io.EOF}}
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.sessionID = ongoingTestSessionID().String()
+	model.setRuntimeActivityBusyForTest(true)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-interrupt-connection-failure", "Proceed?", "Yes", "No"),
+	)})
+
+	next, cancellationCommand := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(*uiModel)
+	if model.transientStatus != "" {
+		t.Fatal("Ctrl+C reported interruption before prompt cancellation completed")
+	}
+	model = updateUIModel(t, model, cancellationCommand())
+	if model.transientStatus != "" {
+		t.Fatal("failed prompt cancellation left an interruption notice")
+	}
+	if testActiveAsk(model) == nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("failed prompt cancellation did not restore the actionable prompt")
+	}
+	if runtimeClient.interruptCalls != 0 {
+		t.Fatalf("runtime interrupt calls = %d, want zero after cancellation failure", runtimeClient.interruptCalls)
 	}
 }
 
@@ -440,6 +476,7 @@ func TestPromptCtrlCContinuationUsesGlobalExitWhenOriginIsIdle(t *testing.T) {
 }
 
 func TestPromptCtrlCContinuationWaitsForPromptActivityToClear(t *testing.T) {
+	disableTransientStatusClearForTest(t)
 	runtimeClient := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(runtimeClient)
 	model.sessionID = ongoingTestSessionID().String()
@@ -618,6 +655,7 @@ func TestPromptCtrlCContinuationCancelsSuccessorInstalledByHydration(t *testing.
 }
 
 func TestStalePromptCtrlCContinuationDoesNotClearNewerPendingContinuation(t *testing.T) {
+	disableTransientStatusClearForTest(t)
 	runtimeClient := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(runtimeClient)
 	model.sessionID = ongoingTestSessionID().String()

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -481,6 +481,88 @@ func TestPromptCtrlCContinuationWaitsForPromptActivityToClear(t *testing.T) {
 	}
 }
 
+func TestPromptCtrlCContinuationCancelsSameStepSuccessorBeforeRuntimeInterrupt(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newRecordingPromptControl()
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.sessionID = ongoingTestSessionID().String()
+	awaitingPrompt := runtimeTupleTestRunningActivity()
+	awaitingPrompt.State = clientui.RuntimeActivityAwaitingPrompt
+	if err := model.applyRuntimeActivityProjection(awaitingPrompt); err != nil {
+		t.Fatalf("apply awaiting-prompt runtime activity: %v", err)
+	}
+	origin := testQuestionPrompt("ask-origin", "Proceed?", "Yes", "No")
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(origin)})
+
+	next, originCancellation := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(*uiModel)
+	originResult := originCancellation().(promptAnswerDeliveryResultMsg)
+	resolved := cloneTranscriptPromptForAsk(origin)
+	resolved.Status = clientui.TranscriptPromptStatusResolved
+	continuation := model.applyAdmittedTranscriptMessageState(
+		clientui.NewTranscriptMessage(2, clientui.NewTranscriptEvent(resolved)),
+		runtimeTupleMergeResult{},
+	)
+	if continuation == nil {
+		t.Fatal("origin resolution did not preserve global Ctrl+C continuation")
+	}
+	if stale := model.askController().applyDeliveryResult(originResult); stale != nil {
+		t.Fatal("origin delivery result scheduled a duplicate continuation")
+	}
+	model = updateUIModel(t, model, continuation())
+
+	successor := testQuestionPrompt("ask-successor", "Anything else?", "Yes", "No")
+	next, successorCommand := model.Update(askEventMsg{event: model.transcriptPromptEvent(successor)})
+	model = next.(*uiModel)
+	var successorContinuation promptCtrlCContinuationMsg
+	for _, message := range collectCmdMessages(t, successorCommand) {
+		if candidate, ok := message.(promptCtrlCContinuationMsg); ok {
+			successorContinuation = candidate
+		}
+	}
+	if successorContinuation.key.promptID == "" {
+		t.Fatal("same-Step successor did not release the pending Ctrl+C continuation")
+	}
+	next, successorCancellation := model.Update(successorContinuation)
+	model = next.(*uiModel)
+	if successorCancellation == nil {
+		t.Fatal("pending Ctrl+C continuation did not cancel the same-Step successor")
+	}
+	successorResult := successorCancellation().(promptAnswerDeliveryResultMsg)
+	next, successorResolvedContinuation := model.Update(successorResult)
+	model = next.(*uiModel)
+	if successorResolvedContinuation == nil {
+		t.Fatal("successor cancellation did not retain global Ctrl+C continuation")
+	}
+	model = updateUIModel(t, model, successorResolvedContinuation())
+	if runtimeClient.interruptCalls != 0 || model.exitAction == UIActionExit {
+		t.Fatal("successor cancellation routed global Ctrl+C while prompt activity was still stale")
+	}
+
+	running := awaitingPrompt
+	running.State = clientui.RuntimeActivityRunning
+	command := model.applyTranscriptRuntimeReadModelUpdate(runtimeTupleMergeResult{
+		decision: runtimeTupleApply,
+		project:  true,
+		view:     clientui.RuntimeMainView{Activity: running},
+	})
+	next, interruptCommand := model.Update(command())
+	model = next.(*uiModel)
+	model = updateUIModel(t, model, interruptCommand())
+	if runtimeClient.interruptCalls != 1 {
+		t.Fatalf("runtime interrupt calls = %d, want one after successor cancellation", runtimeClient.interruptCalls)
+	}
+
+	for index := 0; index < 2; index++ {
+		request := requirePromptAnswerBatchRequest(t, control)
+		if request.Entries[0].Declined == nil {
+			t.Fatalf("prompt cancellation %d = %+v, want declined", index, request)
+		}
+	}
+}
+
 func TestStalePromptCtrlCContinuationDoesNotClearNewerPendingContinuation(t *testing.T) {
 	runtimeClient := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(runtimeClient)

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -318,6 +318,49 @@ func TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt(t *testing.T) 
 	}
 }
 
+func TestAskCtrlCCanonicalResolutionPreservesRuntimeContinuation(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newRecordingPromptControl()
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.setRuntimeActivityBusyForTest(true)
+	prompt := testQuestionPrompt("ask-canonical-interrupt-order", "Proceed?", "Yes", "No")
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(prompt)})
+
+	next, cancellationCommand := model.askController().handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = next.(*uiModel)
+	rawResult := cancellationCommand()
+	result, ok := rawResult.(promptAnswerDeliveryResultMsg)
+	if !ok || result.err != nil {
+		t.Fatalf("prompt cancellation result = %#v, want successful delivery result", rawResult)
+	}
+
+	resolved := cloneTranscriptPromptForAsk(prompt)
+	resolved.Status = clientui.TranscriptPromptStatusResolved
+	message := clientui.NewTranscriptMessage(2, clientui.NewTranscriptEvent(resolved))
+	continuation := model.applyAdmittedTranscriptMessageState(message, runtimeTupleMergeResult{})
+	if continuation == nil {
+		t.Fatal("canonical prompt resolution dropped the pending global Ctrl+C continuation")
+	}
+	if testActiveAsk(model) != nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("canonical prompt resolution retained prompt delivery ownership")
+	}
+	if staleCommand := model.askController().applyDeliveryResult(result); staleCommand != nil {
+		t.Fatal("stale delivery result scheduled a duplicate global Ctrl+C continuation")
+	}
+
+	next, interruptCommand := model.Update(continuation())
+	model = next.(*uiModel)
+	if interruptCommand == nil || runtimeClient.interruptCalls != 0 {
+		t.Fatal("canonical resolution did not defer runtime interruption to its command")
+	}
+	model = updateUIModel(t, model, interruptCommand())
+	if runtimeClient.interruptCalls != 1 {
+		t.Fatalf("runtime interrupt calls = %d, want one after canonical prompt resolution", runtimeClient.interruptCalls)
+	}
+}
+
 func TestAskDeliverySetupFailureKeepsQuestionActivity(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	model, control := newProjectedPromptTestUIModel(t)

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -517,12 +517,14 @@ func TestPromptCtrlCContinuationCancelsSameStepSuccessorBeforeRuntimeInterrupt(t
 	next, successorCommand := model.Update(askEventMsg{event: model.transcriptPromptEvent(successor)})
 	model = next.(*uiModel)
 	var successorContinuation promptCtrlCContinuationMsg
+	foundSuccessorContinuation := false
 	for _, message := range collectCmdMessages(t, successorCommand) {
 		if candidate, ok := message.(promptCtrlCContinuationMsg); ok {
 			successorContinuation = candidate
+			foundSuccessorContinuation = true
 		}
 	}
-	if successorContinuation.key.promptID == "" {
+	if !foundSuccessorContinuation {
 		t.Fatal("same-Step successor did not release the pending Ctrl+C continuation")
 	}
 	next, successorCancellation := model.Update(successorContinuation)
@@ -560,6 +562,58 @@ func TestPromptCtrlCContinuationCancelsSameStepSuccessorBeforeRuntimeInterrupt(t
 		if request.Entries[0].Declined == nil {
 			t.Fatalf("prompt cancellation %d = %+v, want declined", index, request)
 		}
+	}
+}
+
+func TestPromptCtrlCContinuationCancelsSuccessorInstalledByHydration(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newRecordingPromptControl()
+	runtimeClient := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.sessionID = ongoingTestSessionID().String()
+	awaitingPrompt := runtimeTupleTestRunningActivity()
+	awaitingPrompt.State = clientui.RuntimeActivityAwaitingPrompt
+	if err := model.applyRuntimeActivityProjection(awaitingPrompt); err != nil {
+		t.Fatalf("apply awaiting-prompt runtime activity: %v", err)
+	}
+	originKey := transcriptPromptKey{
+		sessionID: ongoingTestSessionID(),
+		stepID:    ongoingTestStepID(),
+		promptID:  "ask-hydration-origin",
+	}
+	model = updateUIModel(t, model, promptCtrlCContinuationMsg{key: originKey})
+
+	hydrationMessage := runtimeTupleTestHydration(2, awaitingPrompt)
+	hydration := hydrationMessage.Payload().(clientui.TranscriptHydration)
+	successor := testQuestionPrompt("ask-hydration-successor", "Anything else?", "Yes", "No")
+	hydration.PendingPrompts = []clientui.TranscriptPrompt{successor}
+	hydrationMessage = clientui.NewTranscriptMessage(1, clientui.NewTranscriptEvent(hydration))
+	command := model.applyAdmittedTranscriptMessageState(hydrationMessage, runtimeTupleMergeResult{
+		decision: runtimeTupleApply,
+		project:  true,
+		view:     clientui.RuntimeMainView{Activity: awaitingPrompt},
+	})
+
+	var successorContinuation promptCtrlCContinuationMsg
+	foundSuccessorContinuation := false
+	for _, message := range collectCmdMessages(t, command) {
+		if candidate, ok := message.(promptCtrlCContinuationMsg); ok {
+			successorContinuation = candidate
+			foundSuccessorContinuation = true
+		}
+	}
+	if !foundSuccessorContinuation {
+		t.Fatal("hydrated same-Step successor did not release the pending Ctrl+C continuation")
+	}
+	next, successorCancellation := model.Update(successorContinuation)
+	model = next.(*uiModel)
+	if successorCancellation == nil {
+		t.Fatal("pending Ctrl+C continuation did not cancel the hydrated successor")
+	}
+	result := successorCancellation().(promptAnswerDeliveryResultMsg)
+	if result.key.promptID != successor.PromptID {
+		t.Fatalf("canceled prompt = %q, want hydrated successor %q", result.key.promptID, successor.PromptID)
 	}
 }
 

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -140,18 +140,25 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.Type {
 	case tea.KeyCtrlC:
+		if m.ask.activeDelivery != nil &&
+			m.ask.activeDelivery.continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
+			return m, nil
+		}
 		c.cancelActiveDelivery()
-		_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
-		interruptCmd := tea.Cmd(nil)
-		if m.blocksRuntimeInput() {
-			_, interruptCmd = m.inputController().handleRuntimeCtrlC(nil)
+		currentToken := m.ask.currentToken
+		accepted, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
+		runtimeCtrlCCmd := tea.Cmd(nil)
+		if m.ask.activeDelivery != nil {
+			m.ask.activeDelivery.continuation = promptAnswerDeliveryContinuationRuntimeCtrlC
+		} else if accepted && (m.ask.currentToken != currentToken || !m.ask.hasCurrent()) && m.blocksRuntimeInput() {
+			_, runtimeCtrlCCmd = m.inputController().handleRuntimeCtrlC(nil)
 		}
 		if hasNext {
 			m.activity = uiActivityQuestion
 		} else {
 			m.activity = uiActivityInterrupted
 		}
-		return m, tea.Batch(answerCmd, interruptCmd, m.interruptedStatusNoticeCmd())
+		return m, tea.Batch(answerCmd, runtimeCtrlCCmd, m.interruptedStatusNoticeCmd())
 	case tea.KeyEsc:
 		c.cancelActiveDelivery()
 		_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("question canceled"))
@@ -482,6 +489,7 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 	if m == nil || !m.ask.activeDelivery.matches(result.key, result.generation) {
 		return nil
 	}
+	continuation := m.ask.activeDelivery.continuation
 	if result.err == nil {
 		c.cancelActiveDelivery()
 		hasNext := c.finishDeliveredPrompt()
@@ -491,6 +499,9 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 			m.activity = uiActivityRunning
 		} else {
 			m.activity = uiActivityIdle
+		}
+		if continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
+			return func() tea.Msg { return promptCtrlCContinuationMsg{} }
 		}
 		return nil
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -316,7 +316,8 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (c uiAskController) handleCtrlC() (tea.Model, tea.Cmd) {
 	m := c.model
 	if m.ask.activeDelivery != nil &&
-		m.ask.activeDelivery.continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
+		m.ask.activeDelivery.continuation != nil &&
+		*m.ask.activeDelivery.continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
 		return m, nil
 	}
 	c.cancelActiveDelivery()
@@ -324,7 +325,8 @@ func (c uiAskController) handleCtrlC() (tea.Model, tea.Cmd) {
 	accepted, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
 	runtimeCtrlCCmd := tea.Cmd(nil)
 	if m.ask.activeDelivery != nil {
-		m.ask.activeDelivery.continuation = promptAnswerDeliveryContinuationRuntimeCtrlC
+		continuation := promptAnswerDeliveryContinuationRuntimeCtrlC
+		m.ask.activeDelivery.continuation = &continuation
 	} else if accepted && (m.ask.currentToken != currentToken || !m.ask.hasCurrent()) && m.blocksRuntimeInput() {
 		_, runtimeCtrlCCmd = m.inputController().handleRuntimeCtrlC(nil)
 	}
@@ -517,18 +519,19 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 }
 
 func promptAnswerDeliveryContinuationCmd(delivery *activePromptAnswerDelivery) tea.Cmd {
-	if delivery == nil {
+	if delivery == nil || delivery.continuation == nil {
 		return nil
 	}
-	switch delivery.continuation {
-	case promptAnswerDeliveryContinuationNone:
-		return nil
+	switch *delivery.continuation {
 	case promptAnswerDeliveryContinuationRuntimeCtrlC:
-		key := delivery.key
-		return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
+		return promptCtrlCContinuationCmd(delivery.key)
 	default:
-		panic(fmt.Sprintf("unknown prompt answer delivery continuation %d", delivery.continuation))
+		panic(fmt.Sprintf("unknown prompt answer delivery continuation %d", *delivery.continuation))
 	}
+}
+
+func promptCtrlCContinuationCmd(key transcriptPromptKey) tea.Cmd {
+	return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
 }
 
 func askVisibleOptions(req clientui.TranscriptPrompt) []string {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -141,25 +141,7 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.Type {
 	case tea.KeyCtrlC:
-		if m.ask.activeDelivery != nil &&
-			m.ask.activeDelivery.continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
-			return m, nil
-		}
-		c.cancelActiveDelivery()
-		currentToken := m.ask.currentToken
-		accepted, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
-		runtimeCtrlCCmd := tea.Cmd(nil)
-		if m.ask.activeDelivery != nil {
-			m.ask.activeDelivery.continuation = promptAnswerDeliveryContinuationRuntimeCtrlC
-		} else if accepted && (m.ask.currentToken != currentToken || !m.ask.hasCurrent()) && m.blocksRuntimeInput() {
-			_, runtimeCtrlCCmd = m.inputController().handleRuntimeCtrlC(nil)
-		}
-		if hasNext {
-			m.activity = uiActivityQuestion
-		} else {
-			m.activity = uiActivityInterrupted
-		}
-		return m, tea.Batch(answerCmd, runtimeCtrlCCmd, m.interruptedStatusNoticeCmd())
+		return c.handleCtrlC()
 	case tea.KeyEsc:
 		c.cancelActiveDelivery()
 		_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("question canceled"))
@@ -329,6 +311,29 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+}
+
+func (c uiAskController) handleCtrlC() (tea.Model, tea.Cmd) {
+	m := c.model
+	if m.ask.activeDelivery != nil &&
+		m.ask.activeDelivery.continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
+		return m, nil
+	}
+	c.cancelActiveDelivery()
+	currentToken := m.ask.currentToken
+	accepted, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
+	runtimeCtrlCCmd := tea.Cmd(nil)
+	if m.ask.activeDelivery != nil {
+		m.ask.activeDelivery.continuation = promptAnswerDeliveryContinuationRuntimeCtrlC
+	} else if accepted && (m.ask.currentToken != currentToken || !m.ask.hasCurrent()) && m.blocksRuntimeInput() {
+		_, runtimeCtrlCCmd = m.inputController().handleRuntimeCtrlC(nil)
+	}
+	if hasNext {
+		m.activity = uiActivityQuestion
+	} else {
+		m.activity = uiActivityInterrupted
+	}
+	return m, tea.Batch(answerCmd, runtimeCtrlCCmd, m.interruptedStatusNoticeCmd())
 }
 
 func (c uiAskController) renderPriorityPromptLines() []askPromptLine {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -88,6 +88,7 @@ func (c uiAskController) resolvePrompt(promptID string) tea.Cmd {
 	if !m.ask.hasCurrent() || strings.TrimSpace(string(m.ask.current.prompt.PromptID)) != targetID {
 		return nil
 	}
+	continuationCmd := promptAnswerDeliveryContinuationCmd(m.ask.activeDelivery)
 	c.cancelActiveDelivery()
 	if len(m.ask.queue) > 0 {
 		next := m.ask.queue[0]
@@ -95,7 +96,7 @@ func (c uiAskController) resolvePrompt(promptID string) tea.Cmd {
 		c.setActiveAsk(next)
 		m.activity = uiActivityQuestion
 		m.setInputMode(uiInputModeAsk)
-		return m.scheduleCurrentQuestionProjection()
+		return tea.Batch(m.scheduleCurrentQuestionProjection(), continuationCmd)
 	}
 	m.ask.current = nil
 	m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)
@@ -113,7 +114,7 @@ func (c uiAskController) resolvePrompt(promptID string) tea.Cmd {
 			m.activity = uiActivityIdle
 		}
 	}
-	return nil
+	return continuationCmd
 }
 
 func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -489,7 +490,7 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 	if m == nil || !m.ask.activeDelivery.matches(result.key, result.generation) {
 		return nil
 	}
-	continuation := m.ask.activeDelivery.continuation
+	continuationCmd := promptAnswerDeliveryContinuationCmd(m.ask.activeDelivery)
 	if result.err == nil {
 		c.cancelActiveDelivery()
 		hasNext := c.finishDeliveredPrompt()
@@ -500,10 +501,7 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 		} else {
 			m.activity = uiActivityIdle
 		}
-		if continuation == promptAnswerDeliveryContinuationRuntimeCtrlC {
-			return func() tea.Msg { return promptCtrlCContinuationMsg{} }
-		}
-		return nil
+		return continuationCmd
 	}
 	c.cancelActiveDelivery()
 	m.activity = uiActivityQuestion
@@ -511,6 +509,20 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 		return nil
 	}
 	return m.sendTransientStatusWithNoticeID(result.err.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
+}
+
+func promptAnswerDeliveryContinuationCmd(delivery *activePromptAnswerDelivery) tea.Cmd {
+	if delivery == nil {
+		return nil
+	}
+	switch delivery.continuation {
+	case promptAnswerDeliveryContinuationNone:
+		return nil
+	case promptAnswerDeliveryContinuationRuntimeCtrlC:
+		return func() tea.Msg { return promptCtrlCContinuationMsg{} }
+	default:
+		panic(fmt.Sprintf("unknown prompt answer delivery continuation %d", delivery.continuation))
+	}
 }
 
 func askVisibleOptions(req clientui.TranscriptPrompt) []string {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -329,13 +329,14 @@ func (c uiAskController) handleCtrlC() (tea.Model, tea.Cmd) {
 		m.ask.activeDelivery.continuation = &continuation
 	} else if accepted && (m.ask.currentToken != currentToken || !m.ask.hasCurrent()) && m.blocksRuntimeInput() {
 		_, runtimeCtrlCCmd = m.inputController().handleRuntimeCtrlC(nil)
+		runtimeCtrlCCmd = tea.Batch(runtimeCtrlCCmd, m.interruptedStatusNoticeCmd())
 	}
 	if hasNext {
 		m.activity = uiActivityQuestion
 	} else {
 		m.activity = uiActivityInterrupted
 	}
-	return m, tea.Batch(answerCmd, runtimeCtrlCCmd, m.interruptedStatusNoticeCmd())
+	return m, tea.Batch(answerCmd, runtimeCtrlCCmd)
 }
 
 func (c uiAskController) renderPriorityPromptLines() []askPromptLine {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -519,7 +519,8 @@ func promptAnswerDeliveryContinuationCmd(delivery *activePromptAnswerDelivery) t
 	case promptAnswerDeliveryContinuationNone:
 		return nil
 	case promptAnswerDeliveryContinuationRuntimeCtrlC:
-		return func() tea.Msg { return promptCtrlCContinuationMsg{} }
+		key := delivery.key
+		return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
 	default:
 		panic(fmt.Sprintf("unknown prompt answer delivery continuation %d", delivery.continuation))
 	}

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -1,11 +1,20 @@
 package app
 
 import (
+	"core/shared/clientui"
 	"runtime/debug"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+)
+
+type promptCtrlCContinuationDisposition uint8
+
+const (
+	promptCtrlCContinuationDiscard promptCtrlCContinuationDisposition = iota
+	promptCtrlCContinuationWait
+	promptCtrlCContinuationRoute
 )
 
 func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
@@ -26,9 +35,20 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case promptCtrlCContinuationMsg:
-		if !m.promptCtrlCContinuationTargetsCurrentExecution(msg) {
+		switch m.promptCtrlCContinuationDisposition(msg.key) {
+		case promptCtrlCContinuationDiscard:
+			m.ask.pendingCtrlCContinuation = nil
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
+		case promptCtrlCContinuationWait:
+			key := msg.key
+			m.ask.pendingCtrlCContinuation = &key
+			m.layout().syncViewport()
+			return handledUIFeatureUpdate(m, nil)
+		case promptCtrlCContinuationRoute:
+			m.ask.pendingCtrlCContinuation = nil
+		default:
+			panic("unknown prompt Ctrl+C continuation disposition")
 		}
 		next, cmd := m.inputController().handleRuntimeCtrlC(nil)
 		nextModel := next.(*uiModel)
@@ -38,18 +58,46 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 	return uiFeatureUpdateResult{}
 }
 
-func (m *uiModel) promptCtrlCContinuationTargetsCurrentExecution(msg promptCtrlCContinuationMsg) bool {
+func (m *uiModel) promptCtrlCContinuationDisposition(key transcriptPromptKey) promptCtrlCContinuationDisposition {
 	if m == nil ||
-		msg.key.sessionID.IsZero() ||
-		msg.key.stepID.IsZero() ||
-		strings.TrimSpace(m.sessionID) != msg.key.sessionID.String() {
-		return false
+		key.sessionID.IsZero() ||
+		key.stepID.IsZero() ||
+		strings.TrimSpace(m.sessionID) != key.sessionID.String() {
+		return promptCtrlCContinuationDiscard
 	}
 	activity := m.runtimeActivityProjection
 	if activity.ActiveStep != nil {
-		return activity.ActiveStep.StepID == msg.key.stepID
+		if activity.ActiveStep.StepID != key.stepID {
+			return promptCtrlCContinuationDiscard
+		}
+		if activity.State == clientui.RuntimeActivityAwaitingPrompt {
+			return promptCtrlCContinuationWait
+		}
+		return promptCtrlCContinuationRoute
 	}
-	return !activity.ActiveForControl() && !m.hasLocalDispatchPending()
+	if activity.ActiveForControl() || m.hasLocalDispatchPending() {
+		return promptCtrlCContinuationDiscard
+	}
+	return promptCtrlCContinuationRoute
+}
+
+func (m *uiModel) releasePendingPromptCtrlCContinuation() tea.Cmd {
+	if m == nil || m.ask.pendingCtrlCContinuation == nil {
+		return nil
+	}
+	key := *m.ask.pendingCtrlCContinuation
+	switch m.promptCtrlCContinuationDisposition(key) {
+	case promptCtrlCContinuationDiscard:
+		m.ask.pendingCtrlCContinuation = nil
+		return nil
+	case promptCtrlCContinuationWait:
+		return nil
+	case promptCtrlCContinuationRoute:
+		m.ask.pendingCtrlCContinuation = nil
+		return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
+	default:
+		panic("unknown prompt Ctrl+C continuation disposition")
+	}
 }
 
 func (m *uiModel) reducePathReferenceMessage(msg tea.Msg) uiFeatureUpdateResult {

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -37,7 +37,7 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 	case promptCtrlCContinuationMsg:
 		switch m.promptCtrlCContinuationDisposition(msg.key) {
 		case promptCtrlCContinuationDiscard:
-			m.ask.pendingCtrlCContinuation = nil
+			m.clearPendingPromptCtrlCContinuation(msg.key)
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		case promptCtrlCContinuationWait:
@@ -46,7 +46,7 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		case promptCtrlCContinuationRoute:
-			m.ask.pendingCtrlCContinuation = nil
+			m.clearPendingPromptCtrlCContinuation(msg.key)
 		default:
 			panic("unknown prompt Ctrl+C continuation disposition")
 		}
@@ -79,6 +79,15 @@ func (m *uiModel) promptCtrlCContinuationDisposition(key transcriptPromptKey) pr
 		return promptCtrlCContinuationDiscard
 	}
 	return promptCtrlCContinuationRoute
+}
+
+func (m *uiModel) clearPendingPromptCtrlCContinuation(key transcriptPromptKey) {
+	if m == nil ||
+		m.ask.pendingCtrlCContinuation == nil ||
+		*m.ask.pendingCtrlCContinuation != key {
+		return
+	}
+	m.ask.pendingCtrlCContinuation = nil
 }
 
 func (m *uiModel) releasePendingPromptCtrlCContinuation() tea.Cmd {

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"runtime/debug"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,12 +26,30 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case promptCtrlCContinuationMsg:
+		if !m.promptCtrlCContinuationTargetsCurrentExecution(msg) {
+			m.layout().syncViewport()
+			return handledUIFeatureUpdate(m, nil)
+		}
 		next, cmd := m.inputController().handleRuntimeCtrlC(nil)
 		nextModel := next.(*uiModel)
 		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	}
 	return uiFeatureUpdateResult{}
+}
+
+func (m *uiModel) promptCtrlCContinuationTargetsCurrentExecution(msg promptCtrlCContinuationMsg) bool {
+	if m == nil ||
+		msg.key.sessionID.IsZero() ||
+		msg.key.stepID.IsZero() ||
+		strings.TrimSpace(m.sessionID) != msg.key.sessionID.String() {
+		return false
+	}
+	activity := m.runtimeActivityProjection
+	if activity.ActiveStep != nil {
+		return activity.ActiveStep.StepID == msg.key.stepID
+	}
+	return !activity.ActiveForControl() && !m.hasLocalDispatchPending()
 }
 
 func (m *uiModel) reducePathReferenceMessage(msg tea.Msg) uiFeatureUpdateResult {

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -127,7 +127,7 @@ func (m *uiModel) releasePendingPromptCtrlCContinuation() tea.Cmd {
 		return nil
 	case promptCtrlCContinuationCancelPrompt, promptCtrlCContinuationRoute:
 		m.ask.pendingCtrlCContinuation = nil
-		return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
+		return promptCtrlCContinuationCmd(key)
 	default:
 		panic("unknown prompt Ctrl+C continuation disposition")
 	}

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -14,6 +14,7 @@ type promptCtrlCContinuationDisposition uint8
 const (
 	promptCtrlCContinuationDiscard promptCtrlCContinuationDisposition = iota
 	promptCtrlCContinuationWait
+	promptCtrlCContinuationCancelPrompt
 	promptCtrlCContinuationRoute
 )
 
@@ -21,6 +22,7 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case askEventMsg:
 		cmd := m.askController().acceptEvent(msg.event)
+		cmd = tea.Batch(cmd, m.releasePendingPromptCtrlCContinuation())
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case questionRenderResultMsg:
@@ -45,6 +47,12 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 			m.ask.pendingCtrlCContinuation = &key
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
+		case promptCtrlCContinuationCancelPrompt:
+			m.clearPendingPromptCtrlCContinuation(msg.key)
+			next, cmd := m.askController().handleCtrlC()
+			nextModel := next.(*uiModel)
+			nextModel.layout().syncViewport()
+			return handledUIFeatureUpdate(nextModel, cmd)
 		case promptCtrlCContinuationRoute:
 			m.clearPendingPromptCtrlCContinuation(msg.key)
 		default:
@@ -70,6 +78,9 @@ func (m *uiModel) promptCtrlCContinuationDisposition(key transcriptPromptKey) pr
 		if activity.ActiveStep.StepID != key.stepID {
 			return promptCtrlCContinuationDiscard
 		}
+		if m.activePromptContinuesCtrlC(key) {
+			return promptCtrlCContinuationCancelPrompt
+		}
 		if activity.State == clientui.RuntimeActivityAwaitingPrompt {
 			return promptCtrlCContinuationWait
 		}
@@ -79,6 +90,19 @@ func (m *uiModel) promptCtrlCContinuationDisposition(key transcriptPromptKey) pr
 		return promptCtrlCContinuationDiscard
 	}
 	return promptCtrlCContinuationRoute
+}
+
+func (m *uiModel) activePromptContinuesCtrlC(key transcriptPromptKey) bool {
+	if m == nil || !m.ask.hasCurrent() {
+		return false
+	}
+	activeKey, err := newTranscriptPromptKey(m.ask.current.prompt)
+	if err != nil {
+		return false
+	}
+	return activeKey.sessionID == key.sessionID &&
+		activeKey.stepID == key.stepID &&
+		activeKey.promptID != key.promptID
 }
 
 func (m *uiModel) clearPendingPromptCtrlCContinuation(key transcriptPromptKey) {
@@ -101,7 +125,7 @@ func (m *uiModel) releasePendingPromptCtrlCContinuation() tea.Cmd {
 		return nil
 	case promptCtrlCContinuationWait:
 		return nil
-	case promptCtrlCContinuationRoute:
+	case promptCtrlCContinuationCancelPrompt, promptCtrlCContinuationRoute:
 		m.ask.pendingCtrlCContinuation = nil
 		return func() tea.Msg { return promptCtrlCContinuationMsg{key: key} }
 	default:

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -60,6 +60,7 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 		}
 		next, cmd := m.inputController().handleRuntimeCtrlC(nil)
 		nextModel := next.(*uiModel)
+		cmd = tea.Batch(cmd, nextModel.interruptedStatusNoticeCmd())
 		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	}

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -24,6 +24,11 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 		cmd := m.askController().applyDeliveryResult(msg)
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
+	case promptCtrlCContinuationMsg:
+		next, cmd := m.inputController().handleRuntimeCtrlC(nil)
+		nextModel := next.(*uiModel)
+		nextModel.layout().syncViewport()
+		return handledUIFeatureUpdate(nextModel, cmd)
 	}
 	return uiFeatureUpdateResult{}
 }

--- a/cli/app/ui_input_mode.go
+++ b/cli/app/ui_input_mode.go
@@ -25,18 +25,19 @@ type uiInteractionState struct {
 }
 
 type uiAskState struct {
-	current                 *askEvent
-	currentToken            uint64
-	queue                   []askEvent
-	cursor                  int
-	freeform                bool
-	freeformMode            askFreeformMode
-	activeDelivery          *activePromptAnswerDelivery
-	answerPending           bool
-	editor                  tuiinput.Editor
-	activeProjection        *activeQuestionProjection
-	inFlightProjection      *questionRenderRequest
-	latestDesiredProjection *desiredQuestionProjection
+	current                  *askEvent
+	currentToken             uint64
+	queue                    []askEvent
+	cursor                   int
+	freeform                 bool
+	freeformMode             askFreeformMode
+	activeDelivery           *activePromptAnswerDelivery
+	pendingCtrlCContinuation *transcriptPromptKey
+	answerPending            bool
+	editor                   tuiinput.Editor
+	activeProjection         *activeQuestionProjection
+	inFlightProjection       *questionRenderRequest
+	latestDesiredProjection  *desiredQuestionProjection
 }
 
 type uiProcessListState struct {

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -107,6 +107,7 @@ func (m *uiModel) applyTranscriptHydration(
 
 	m.reconcileTranscriptQueuedMessages(hydration.QueuedMessages)
 	cmds = append(cmds, m.reconcileTranscriptPrompts(hydration.PendingPrompts))
+	cmds = append(cmds, m.releasePendingPromptCtrlCContinuation())
 	currentSessionID := strings.TrimSpace(m.sessionID)
 	preserved := m.processList.entries[:0]
 	for _, entry := range m.processList.entries {

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -220,6 +220,7 @@ func (m *uiModel) applyTranscriptSessionIdentity(identity clientui.TranscriptSes
 	if previousSessionID == "" || previousSessionID == nextSessionID {
 		return titleCmd
 	}
+	m.askController().cancelActiveDelivery()
 	promptCmd := m.reconcileTranscriptPrompts(nil)
 	rollbackCmd := m.discardRollbackStateForSessionReplacement()
 	cancelCmd := m.cancelPendingDetailTranscriptRequest()

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -149,14 +149,15 @@ func (m *uiModel) applyTranscriptRuntimeReadModelUpdate(admission runtimeTupleMe
 			"",
 		)
 	}
+	promptCtrlCCmd := m.releasePendingPromptCtrlCContinuation()
 	if view.Activity.ActiveForControl() {
-		return nil
+		return promptCtrlCCmd
 	}
 	var cmd tea.Cmd
 	if m.hasPendingInterrupt() {
 		cmd = m.acknowledgePendingInterrupt()
 	}
-	return tea.Batch(cmd, m.releaseDeferredRuntimeSyncs())
+	return tea.Batch(promptCtrlCCmd, cmd, m.releaseDeferredRuntimeSyncs())
 }
 
 func (m *uiModel) applyTranscriptStepState(state clientui.TranscriptStepState) {
@@ -221,6 +222,7 @@ func (m *uiModel) applyTranscriptSessionIdentity(identity clientui.TranscriptSes
 		return titleCmd
 	}
 	m.askController().cancelActiveDelivery()
+	m.ask.pendingCtrlCContinuation = nil
 	promptCmd := m.reconcileTranscriptPrompts(nil)
 	rollbackCmd := m.discardRollbackStateForSessionReplacement()
 	cancelCmd := m.cancelPendingDetailTranscriptRequest()


### PR DESCRIPTION
## Summary
- finish typed Question cancellation before routing global Ctrl+C handling
- make repeated Ctrl+C idempotent while cancellation delivery is in flight
- continue to runtime interrupt/exit only after successful prompt cancellation

## Verification
- `./scripts/test.sh -run '^(TestAskCtrlCFinishesPromptCancellationBeforeRuntimeInterrupt|TestAskRepeatedEnterWhileDeliveryActiveDoesNotSubmitAgain|TestAskDeliverySetupFailureKeepsQuestionActivity|TestRuntimeCtrlCExitsWhenNoAgentLoopIsRunning|TestRuntimeCtrlCInterruptsRestartedAgentLoopInsteadOfQuitting)$' ./cli/app`\n- `./scripts/build.sh --output ./bin/kent`\n- isolated OMLX TUI QA: reproduced a pending Question, sent 10 rapid Ctrl+C presses, observed one cancellation, no `runtime command was not accepted` spam, prompt removal, and clean exit\n\nNo `--full` test run.