### PR TITLE
fix: flush shell output before exit publication

### DIFF
--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -182,6 +182,7 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 		stdinOpen:            req.KeepStdinOpen,
 		notify:               make(chan struct{}, 1),
 		done:                 make(chan struct{}),
+		outputFinalized:      make(chan struct{}),
 	}
 	entry.log = newAsyncLogWriter(logFile, entry.signal)
 	if entry.command == "" {

--- a/server/tools/shell/manager_output.go
+++ b/server/tools/shell/manager_output.go
@@ -46,14 +46,14 @@ func (s *outputSubscription) Next(ctx context.Context) (OutputChunk, error) {
 		}
 
 		notify := s.entry.notify
-		doneCh := s.entry.done
+		outputFinalized := s.entry.outputFinalized
 		select {
 		case <-ctx.Done():
 			return OutputChunk{}, ctx.Err()
 		case <-s.closeCh:
 			return OutputChunk{}, io.EOF
 		case <-notify:
-		case <-doneCh:
+		case <-outputFinalized:
 		}
 	}
 }
@@ -76,7 +76,6 @@ func (s *outputSubscription) readNextChunk() (OutputChunk, bool, error) {
 	}
 	s.entry.mu.Lock()
 	logPath := s.entry.logPath
-	running := s.entry.running
 	preserveOutput := s.entry.preserveOutput
 	s.entry.mu.Unlock()
 
@@ -107,7 +106,12 @@ func (s *outputSubscription) readNextChunk() (OutputChunk, bool, error) {
 		s.offset = nextOffset
 		return chunk, false, nil
 	}
-	return OutputChunk{}, !running, nil
+	select {
+	case <-s.entry.outputFinalized:
+		return OutputChunk{}, true, nil
+	default:
+		return OutputChunk{}, false, nil
+	}
 }
 
 var _ OutputSubscription = (*outputSubscription)(nil)

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -394,7 +394,6 @@ func (p *processEntry) isBackgrounded() bool {
 
 func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Lock()
-	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -403,6 +402,7 @@ func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
 	p.mu.Lock()
+	p.running = false
 	snapshot := p.snapshotLocked()
 	p.mu.Unlock()
 	p.signal()

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -268,6 +268,7 @@ type processEntry struct {
 	outputBytes          int64
 	notify               chan struct{}
 	done                 chan struct{}
+	outputFinalized      chan struct{}
 	killRequested        bool
 	terminalEvent        *terminalEventCache
 	terminalDelivered    bool
@@ -345,6 +346,11 @@ func closeDetachedResources(stdin io.Closer, log *asyncLogWriter) {
 	}
 }
 
+func (p *processEntry) finalizeOutput() {
+	close(p.outputFinalized)
+	p.signal()
+}
+
 func (p *processEntry) writeOutput(chunk []byte) error {
 	if len(chunk) == 0 {
 		return nil
@@ -383,7 +389,7 @@ func (p *processEntry) setExited(exitCode int, state string) {
 	stdin, log := p.detachResourcesLocked()
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
-	p.signal()
+	p.finalizeOutput()
 }
 
 func (p *processEntry) isBackgrounded() bool {
@@ -394,6 +400,7 @@ func (p *processEntry) isBackgrounded() bool {
 
 func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Lock()
+	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -401,11 +408,10 @@ func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	stdin, log := p.detachResourcesLocked()
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
+	p.finalizeOutput()
 	p.mu.Lock()
-	p.running = false
 	snapshot := p.snapshotLocked()
 	p.mu.Unlock()
-	p.signal()
 	return snapshot
 }
 


### PR DESCRIPTION
## Summary
- keep background shell output streams live until the async log writer has flushed and closed
- preserve the new shutdown behavior that waits on `running` instead of terminal-event delivery
- closes the final valid post-merge review finding from #815

## Verification
- `./scripts/test.sh ./server/tools/shell`
- focused output-flush and shutdown regressions, 5 repetitions
- `./scripts/build.sh --output ./bin/kent`