### PR TITLE
fix: allow Script nodes after Join

### DIFF
--- a/docs/src/content/docs/workflows.md
+++ b/docs/src/content/docs/workflows.md
@@ -166,6 +166,8 @@ A previous-transition parameter is valid only when every path to the prompt pass
 
 Use a Script node when a workflow step should run a deterministic local executable instead of an agent. Script nodes can be used anywhere an agent node can be used in the workflow graph.
 
+In complete graph documents, transitions into Script nodes use `context_mode: "new_session"` and `context_source: {"kind":"immediate_source"}`. These required context fields do not create or select a Session for the Script node.
+
 Set the script path on the script node. **All paths are resolved on the server machine.** Relative paths resolve against the task's execution root.
 
 The node script receiver JSON as stdin:

--- a/server/workflow/session_reuse_analysis.go
+++ b/server/workflow/session_reuse_analysis.go
@@ -294,13 +294,14 @@ func (a sessionReuseAnalyzer) applyEdge(state reusePathState, edge Edge) (reuseT
 	groupEdges := a.edgesByGroup[edge.TransitionGroupID]
 	targetBranch := a.nextBranch(state.branch, edge, target, len(groupEdges))
 	if a.staticValidation {
-		requiresMergedSource := target.Kind() != NodeKindTerminal &&
-			CanonicalContextSource(edge.ContextSource).Kind != ContextSourceSelectedNode &&
-			(edge.ContextMode != ContextModeNewSession || target.Kind() != NodeKindAgent)
-		if (isRetainedTargetContextSource(edge.ContextSource) &&
-			state.staticSource.kind != staticContinuationSourceExact) ||
-			(requiresMergedSource && state.staticSource.kind == staticContinuationSourceDivergent) {
-			a.staticInvalidEdges[edge.ID] = struct{}{}
+		if target.Kind() == NodeKindAgent {
+			requiresMergedSource := CanonicalContextSource(edge.ContextSource).Kind != ContextSourceSelectedNode &&
+				edge.ContextMode != ContextModeNewSession
+			if (isRetainedTargetContextSource(edge.ContextSource) &&
+				state.staticSource.kind != staticContinuationSourceExact) ||
+				(requiresMergedSource && state.staticSource.kind == staticContinuationSourceDivergent) {
+				a.staticInvalidEdges[edge.ID] = struct{}{}
+			}
 		}
 		return reuseTransition{target: reusePathState{
 			nodeID: edge.TargetNodeID,

--- a/server/workflow/validation_test.go
+++ b/server/workflow/validation_test.go
@@ -710,7 +710,7 @@ func TestJoinOutgoingApprovalIsUnsupported(t *testing.T) {
 	assertHasCodes(t, result, workflow.CodeUnsupportedApprovalExecution)
 }
 
-func TestFanoutJoinRejectsDivergentSourceCarriedIntoScript(t *testing.T) {
+func TestFanoutJoinAllowsScriptTargetWithoutContinuationSource(t *testing.T) {
 	def := fanoutWorkflow(t)
 	script := testNode(
 		def.ID,
@@ -726,7 +726,7 @@ func TestFanoutJoinRejectsDivergentSourceCarriedIntoScript(t *testing.T) {
 	joinEdge.ContextMode = workflow.ContextModeNewSession
 	def.TransitionGroups = append(def.TransitionGroups, workflow.TransitionGroup{
 		WorkflowID: def.ID, ID: "group_script_done",
-		SourceNodeID: workflow.NodeIDOf(script), TransitionID: "done", DisplayName: "Done",
+		SourceNodeID: workflow.NodeIDOf(script), TransitionID: "script_done", DisplayName: "Done",
 	})
 	def.Edges = append(def.Edges, workflow.Edge{
 		WorkflowID: def.ID, ID: "edge_script_done", Key: "done",
@@ -737,7 +737,9 @@ func TestFanoutJoinRejectsDivergentSourceCarriedIntoScript(t *testing.T) {
 
 	result := validateForTask(def)
 
-	assertHasCodes(t, result, workflow.CodeInvalidContextSource)
+	if len(result.Errors) != 0 {
+		t.Fatalf("Join-to-Script workflow validation errors = %+v", result.Errors)
+	}
 }
 
 func TestContextSourceValidation(t *testing.T) {

--- a/server/workflowstore/current_node_completion_test.go
+++ b/server/workflowstore/current_node_completion_test.go
@@ -288,6 +288,65 @@ func TestCompleteCurrentNodeJoinContinuationReturnsTargetNodeKind(t *testing.T) 
 	}
 }
 
+func TestCompleteCurrentNodeJoinCreatesScriptWithAggregatedInput(t *testing.T) {
+	ctx, store, binding, cfg := newTestStoreWithConfigContext(t)
+	workflowID := createFanoutJoinWorkflow(t, ctx, store)
+	saveWorkflowGraphFixture(t, ctx, store, workflowID, func(def workflow.Definition, req *WorkflowGraphSaveRequest) {
+		script := nodeByKey(t, def, "synth")
+		record := workflowGraphSaveNodeRecord(t, req.Nodes, workflow.NodeIDOf(script))
+		record.Kind = workflow.NodeKindScript
+		record.SubagentRole = ""
+		record.ScriptPath = "/usr/bin/true"
+		workflowGraphSaveEdgeRecord(
+			t,
+			req.Edges,
+			testEdgeID("edge-join-synth-"+workflowID.String()),
+		).PromptTemplate = ""
+	})
+	linkWorkflow(t, ctx, store, binding.ProjectID, workflowID, true)
+	task := createDefaultTask(t, ctx, store, binding.ProjectID)
+	source := startTask(t, ctx, store, task.ID).Mutation.Created[0]
+
+	split, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       source.Reference,
+		OutputValues: map[string]string{"summary": "plan complete"},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCurrentNode split: %v", err)
+	}
+	branches := make(map[workflow.TransitionBranchKey]workflow.CurrentNode)
+	for _, currentNode := range split.Mutation.Created {
+		branchKey, present := currentNode.Reference.TransitionBranchKey()
+		if !present {
+			t.Fatalf("fan-out Current Node = %+v, want branch scope", currentNode)
+		}
+		branches[branchKey] = currentNode
+		associateAndBindCurrentNodeSessionForTest(t, ctx, store, binding, cfg, currentNode.Reference)
+	}
+	if _, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       branches["split_a"].Reference,
+		TransitionID: "join_a",
+		OutputValues: map[string]string{"joined": "branch aggregate"},
+	}); err != nil {
+		t.Fatalf("CompleteCurrentNode first join arrival: %v", err)
+	}
+	joined, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       branches["split_b"].Reference,
+		TransitionID: "join_b",
+	})
+	if err != nil {
+		t.Fatalf("CompleteCurrentNode second join arrival: %v", err)
+	}
+	if len(joined.Mutation.Created) != 1 ||
+		joined.Mutation.Created[0].CurrentInputValues["joined"] != "branch aggregate" {
+		t.Fatalf("join Script successor = %+v, want aggregated input", joined.Mutation.Created)
+	}
+	if len(joined.AutomaticIntents) != 1 ||
+		joined.AutomaticIntents[0].NodeKind != workflow.NodeKindScript {
+		t.Fatalf("join automatic intents = %+v, want one Script successor", joined.AutomaticIntents)
+	}
+}
+
 func TestCompleteCurrentNodeRequiresTransitionIDForSeveralOutgoingTransitions(t *testing.T) {
 	ctx, store, binding := newTestStoreContext(t)
 	workflowID := createMaterializedCurrentNodeWorkflow(t, ctx, store)

--- a/server/workflowstore/current_node_join.go
+++ b/server/workflowstore/current_node_join.go
@@ -117,9 +117,9 @@ func completeCurrentNodeJoinArrival(
 	}
 	joinContinuationSource := workflow.AbsentMaterializedContinuationSource()
 	contextSource := workflow.CanonicalContextSource(target.Edge.ContextSource)
-	if target.Node.Kind() != workflow.NodeKindTerminal &&
-		contextSource.Kind != workflow.ContextSourceSelectedNode &&
-		(target.Edge.ContextMode != workflow.ContextModeNewSession || target.Node.Kind() != workflow.NodeKindAgent) {
+	if target.Node.Kind() == workflow.NodeKindAgent &&
+		target.Edge.ContextMode != workflow.ContextModeNewSession &&
+		contextSource.Kind != workflow.ContextSourceSelectedNode {
 		joinContinuationSource, err = mergeCurrentFanoutJoinContinuationSources(arrivals)
 		if err != nil {
 			return CurrentNodeCompletionResult{}, err


### PR DESCRIPTION
## Summary
- validate Join-to-Script transitions without requiring one merged Agent Session source
- create the Script successor with aggregated Join parameters even when branch Sessions differ
- document the graph-document context representation for Script targets

## Verification
- `just test server --no-wall-clock-cap -- ./server/workflow ./server/workflowstore ./server/workflowrunner`
- `just check docs`
- `just build go --output ./bin/kent`
- pre-push `just check --dry-run`

Closes #814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Script nodes can now be valid targets after fan-out and join transitions without requiring a continuation source.
  * Join processing correctly aggregates branch input before passing it to Script nodes.
  * Agent continuation validation remains enforced where applicable.

* **Documentation**
  * Documented the required context settings for transitions into Script nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->