### PR TITLE
fix: repair 2.7.0 release workflow

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-repo_root="$(git rev-parse --show-toplevel)"
-
-cd "$repo_root"
-just lint --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,44 @@ jobs:
           persist-credentials: false
 
       - uses: extractions/setup-just@v3
+        if: matrix.runs_on != 'windows-11-arm'
+
+      - name: Install just on Windows ARM
+        if: matrix.runs_on == 'windows-11-arm'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $headers = @{
+            Authorization = "Bearer $env:GH_TOKEN"
+            Accept = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $release = Invoke-RestMethod `
+            -Headers $headers `
+            -Uri "https://api.github.com/repos/casey/just/releases/latest"
+          $assets = @(
+            $release.assets |
+              Where-Object { $_.name -like "*-aarch64-pc-windows-msvc.zip" }
+          )
+          if ($assets.Count -ne 1) {
+            throw "Expected exactly one Windows ARM64 just asset, found $($assets.Count)"
+          }
+
+          $archive = Join-Path $env:RUNNER_TEMP "just-windows-arm64.zip"
+          $installRoot = Join-Path $env:RUNNER_TEMP "just-windows-arm64"
+          Invoke-WebRequest `
+            -Headers $headers `
+            -Uri $assets[0].browser_download_url `
+            -OutFile $archive
+          Expand-Archive -Path $archive -DestinationPath $installRoot
+
+          $executables = @(Get-ChildItem -Path $installRoot -Filter just.exe -Recurse)
+          if ($executables.Count -ne 1) {
+            throw "Expected exactly one just.exe, found $($executables.Count)"
+          }
+          $executables[0].DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Append
+          & $executables[0].FullName --version
 
       - name: Download release artifacts
         uses: actions/download-artifact@v8.0.1
@@ -316,6 +354,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: apps/desktop/src-tauri
+
+      - uses: actions/setup-go@v6.5.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      JUST_VERSION: 1.58.0
+      JUST_WINDOWS_ARM64_SHA256: 3a39ed629eb67678976c811a4da46f7985a2c22f4dbabe017b8b2eb5ceb5d01c
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -214,35 +217,25 @@ jobs:
 
       - uses: extractions/setup-just@v3
         if: matrix.runs_on != 'windows-11-arm'
+        with:
+          just-version: ${{ env.JUST_VERSION }}
 
       - name: Install just on Windows ARM
         if: matrix.runs_on == 'windows-11-arm'
         shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          $headers = @{
-            Authorization = "Bearer $env:GH_TOKEN"
-            Accept = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-          $release = Invoke-RestMethod `
-            -Headers $headers `
-            -Uri "https://api.github.com/repos/casey/just/releases/latest"
-          $assets = @(
-            $release.assets |
-              Where-Object { $_.name -like "*-aarch64-pc-windows-msvc.zip" }
-          )
-          if ($assets.Count -ne 1) {
-            throw "Expected exactly one Windows ARM64 just asset, found $($assets.Count)"
-          }
-
+          $assetName = "just-$env:JUST_VERSION-aarch64-pc-windows-msvc.zip"
           $archive = Join-Path $env:RUNNER_TEMP "just-windows-arm64.zip"
           $installRoot = Join-Path $env:RUNNER_TEMP "just-windows-arm64"
           Invoke-WebRequest `
-            -Headers $headers `
-            -Uri $assets[0].browser_download_url `
+            -Uri "https://github.com/casey/just/releases/download/$env:JUST_VERSION/$assetName" `
             -OutFile $archive
+
+          $actualHash = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:JUST_WINDOWS_ARM64_SHA256) {
+            throw "Windows ARM64 just archive SHA-256 mismatch: expected $env:JUST_WINDOWS_ARM64_SHA256, got $actualHash"
+          }
+
           Expand-Archive -Path $archive -DestinationPath $installRoot
 
           $executables = @(Get-ChildItem -Path $installRoot -Filter just.exe -Recurse)

--- a/cli/app/internal/ptyfixture/lifecycle_hook_integration_test.go
+++ b/cli/app/internal/ptyfixture/lifecycle_hook_integration_test.go
@@ -76,7 +76,7 @@ func TestLifecycleHooksLocalConfiguredPTYRunsRepresentativeFlow(t *testing.T) {
 			{Phase: pty.PhasePromptReady, Bytes: []byte("\r")},
 			{Phase: pty.PhaseLifecycleHooksObserved, Bytes: []byte{0x03, 0x03}},
 		},
-		Timeout: 5 * time.Second,
+		Timeout: ptyFixtureCommandTimeout,
 	})
 	if err != nil {
 		t.Fatalf("run local lifecycle PTY fixture: %v raw=%q", err, string(capture.Raw))
@@ -175,7 +175,7 @@ func TestLifecycleHooksRemotePTYRunsInControllingClient(t *testing.T) {
 			Phase: pty.PhaseLifecycleHooksObserved,
 			Bytes: []byte{0x03, 0x03},
 		}},
-		Timeout: 5 * time.Second,
+		Timeout: ptyFixtureCommandTimeout,
 	})
 	if err != nil {
 		t.Fatalf("run remote lifecycle PTY fixture: %v raw=%q server=%q", err, string(capture.Raw), serverOutput.String())
@@ -228,7 +228,7 @@ func TestLifecycleHookFailureIsVisibleAndDoesNotBlockPTYRuntime(t *testing.T) {
 			After: 2 * time.Second,
 			Bytes: []byte{0x03, 0x03},
 		}},
-		Timeout: 5 * time.Second,
+		Timeout: ptyFixtureCommandTimeout,
 	})
 	if err != nil {
 		t.Fatalf("run failing-hook lifecycle PTY fixture: %v raw=%q", err, string(capture.Raw))

--- a/cli/app/internal/ptyfixture/ongoing_scrollback_scenarios_test.go
+++ b/cli/app/internal/ptyfixture/ongoing_scrollback_scenarios_test.go
@@ -339,7 +339,7 @@ func runPTYFixtureScenarioWithInputPlan(t *testing.T, ctx context.Context, bin s
 		FrameInputSequences: inputPlan.frameSequences,
 		FrameResizes:        inputPlan.frameResizes,
 		Resizes:             resizes,
-		Timeout:             5 * time.Second,
+		Timeout:             ptyFixtureCommandTimeout,
 	})
 	if err != nil {
 		t.Fatalf("run fixture: %v raw=%q", err, string(capture.Raw))

--- a/cli/app/internal/ptyfixture/process_test.go
+++ b/cli/app/internal/ptyfixture/process_test.go
@@ -20,8 +20,9 @@ type ptyFixtureBinaryBuild struct {
 }
 
 const (
-	ptyFixtureTestTimeout = 5 * time.Second
-	ptyFixtureBinaryEnv   = "KENT_PTY_FIXTURE_BINARY"
+	ptyFixtureCommandTimeout = 30 * time.Second
+	ptyFixtureTestTimeout    = 45 * time.Second
+	ptyFixtureBinaryEnv      = "KENT_PTY_FIXTURE_BINARY"
 )
 
 var (

--- a/internal/testharness/pty/blackbox/blackbox_test.go
+++ b/internal/testharness/pty/blackbox/blackbox_test.go
@@ -426,7 +426,7 @@ func TestResponsesStubRejectsConcurrentDeclaredOperation(t *testing.T) {
 		}
 		firstDone <- requestErr
 	}()
-	waitForActiveRequest(t, stub)
+	waitForRequiredOperationAdmission(t, stub, 1)
 	response, err := http.Post(stub.URL()+"/responses", "application/json", bytes.NewBufferString(`{"input":[]}`))
 	if err != nil {
 		t.Fatalf("POST concurrent request: %v", err)
@@ -446,15 +446,22 @@ func TestResponsesStubRejectsConcurrentDeclaredOperation(t *testing.T) {
 	}
 }
 
-func waitForActiveRequest(t *testing.T, stub *blackbox.ResponsesStub) {
+func waitForRequiredOperationAdmission(t *testing.T, stub *blackbox.ResponsesStub, admitted int) {
 	t.Helper()
 	deadline := time.NewTimer(time.Second)
 	defer deadline.Stop()
-	for stub.Snapshot().ActiveRequests == 0 {
+	for {
+		snapshot := stub.Snapshot()
+		if snapshot.Failure != nil {
+			t.Fatalf("model request failed before operation admission: %v", snapshot.Failure)
+		}
+		if snapshot.RequiredIndex >= admitted {
+			return
+		}
 		select {
 		case <-stub.Events():
 		case <-deadline.C:
-			t.Fatal("model request did not become active")
+			t.Fatalf("model operation admission = %d, want at least %d", snapshot.RequiredIndex, admitted)
 		}
 	}
 }

--- a/internal/testharness/pty/blackbox/stub.go
+++ b/internal/testharness/pty/blackbox/stub.go
@@ -246,6 +246,7 @@ func (s *ResponsesStub) Close() {
 
 func (s *ResponsesStub) serveRoute(route Route) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
+		requestRoute := route
 		ctx, done, admitted := s.beginHandler(request.Context())
 		if !admitted {
 			http.Error(writer, "model stub is stopping", http.StatusServiceUnavailable)
@@ -269,27 +270,27 @@ func (s *ResponsesStub) serveRoute(route Route) http.HandlerFunc {
 			http.Error(writer, "invalid request", http.StatusRequestEntityTooLarge)
 			return
 		}
-		if route == RouteResponses {
-			route, err = classifyResponsesOperation(body)
+		if requestRoute == RouteResponses {
+			requestRoute, err = classifyResponsesOperation(body)
 			if err != nil {
 				s.recordFailure(err)
 				http.Error(writer, "invalid request", http.StatusBadRequest)
 				return
 			}
 		}
-		if err := validateRouteBody(route, body); err != nil {
+		if err := validateRouteBody(requestRoute, body); err != nil {
 			s.recordFailure(err)
 			http.Error(writer, "invalid request", http.StatusBadRequest)
 			return
 		}
-		call := ObservedCall{Route: route, Headers: request.Header.Clone(), Body: append(json.RawMessage(nil), body...)}
+		call := ObservedCall{Route: requestRoute, Headers: request.Header.Clone(), Body: append(json.RawMessage(nil), body...)}
 		if err := s.recordObserved(call); err != nil {
 			s.recordFailure(err)
 			http.Error(writer, "model diagnostics exceed limit", http.StatusRequestEntityTooLarge)
 			return
 		}
 		if s.scripted != nil {
-			admission, err := s.serveScripted(ctx, writer, request, route, body)
+			admission, err := s.serveScripted(ctx, writer, request, requestRoute, body)
 			if err != nil {
 				if admission == scriptedllm.RequestAdmitted ||
 					(!errors.Is(err, scriptedllm.ErrConcurrentCall) && !errors.Is(err, scriptedllm.ErrScriptExhausted)) {
@@ -301,7 +302,7 @@ func (s *ResponsesStub) serveRoute(route Route) http.HandlerFunc {
 			}
 			return
 		}
-		operation, err := s.consume(route, body, request.Header)
+		operation, err := s.consume(requestRoute, body, request.Header)
 		if err != nil {
 			s.recordFailure(err)
 			http.Error(writer, "unexpected model operation", http.StatusBadRequest)
@@ -310,7 +311,7 @@ func (s *ResponsesStub) serveRoute(route Route) http.HandlerFunc {
 		if operation != nil {
 			defer s.completeRequired()
 		}
-		s.writeOperationResponse(ctx, writer, route, operation)
+		s.writeOperationResponse(ctx, writer, requestRoute, operation)
 	}
 }
 

--- a/internal/testharness/pty/driver/driver.go
+++ b/internal/testharness/pty/driver/driver.go
@@ -31,11 +31,8 @@ func RunCommand(ctx context.Context, spec CommandSpec) (analyzer.Capture, error)
 	defer cancel()
 	commandTimeout := spec.Timeout
 	if commandTimeout == 0 {
-		commandTimeout = maxCommandTimeout
+		commandTimeout = defaultCommandTimeout
 	}
-	var timeoutCancel context.CancelFunc
-	ctx, timeoutCancel = context.WithTimeout(ctx, commandTimeout)
-	defer timeoutCancel()
 	if _, err := analyzer.NewDimensions(spec.Dimensions.Rows, spec.Dimensions.Cols); err != nil {
 		return analyzer.Capture{}, err
 	}
@@ -57,7 +54,6 @@ func RunCommand(ctx context.Context, spec CommandSpec) (analyzer.Capture, error)
 	cmd.Env = append(os.Environ(), spec.Env...)
 	cmd.Dir = spec.Dir
 
-	started := time.Now()
 	ptmx, err := creackpty.StartWithSize(cmd, &creackpty.Winsize{Rows: uint16(spec.Dimensions.Rows), Cols: uint16(spec.Dimensions.Cols)})
 	if err != nil {
 		return analyzer.Capture{}, errors.Join(
@@ -68,6 +64,10 @@ func RunCommand(ctx context.Context, spec CommandSpec) (analyzer.Capture, error)
 	defer func() {
 		_ = ptmx.Close()
 	}()
+	started := time.Now()
+	var timeoutCancel context.CancelFunc
+	ctx, timeoutCancel = context.WithTimeout(ctx, commandTimeout)
+	defer timeoutCancel()
 	waitDone := make(chan error, 1)
 	var processExited atomic.Bool
 	go func() {

--- a/internal/testharness/pty/driver/driver_test.go
+++ b/internal/testharness/pty/driver/driver_test.go
@@ -19,13 +19,17 @@ import (
 	"github.com/google/uuid"
 )
 
-const commandTestTimeout = 5 * time.Second
+const (
+	commandDefaultTimeout = 5 * time.Second
+	commandTestTimeout    = 30 * time.Second
+	commandTimeoutCap     = time.Minute
+)
 
 func TestRunCommandRejectsTimeoutAboveHarnessBudget(t *testing.T) {
 	_, err := driver.RunCommand(context.Background(), driver.CommandSpec{
 		Path:       "unused",
 		Dimensions: pty.MustDimensions(2, 8),
-		Timeout:    commandTestTimeout + time.Nanosecond,
+		Timeout:    commandTimeoutCap + time.Nanosecond,
 	})
 	if err == nil || !strings.Contains(err.Error(), "exceeds PTY command timeout cap") {
 		t.Fatalf("RunCommand error = %v, want timeout-cap error", err)
@@ -42,8 +46,8 @@ func TestRunCommandAppliesHarnessBudgetWhenTimeoutIsOmitted(t *testing.T) {
 	if !errors.As(err, new(*driver.TimeoutError)) {
 		t.Fatalf("RunCommand error = %v, want TimeoutError", err)
 	}
-	if elapsed := time.Since(started); elapsed > commandTestTimeout+time.Second {
-		t.Fatalf("RunCommand elapsed = %s, want hard cap near %s", elapsed, commandTestTimeout)
+	if elapsed := time.Since(started); elapsed > commandDefaultTimeout+time.Second {
+		t.Fatalf("RunCommand elapsed = %s, want hard cap near %s", elapsed, commandDefaultTimeout)
 	}
 }
 

--- a/internal/testharness/pty/driver/session.go
+++ b/internal/testharness/pty/driver/session.go
@@ -20,6 +20,7 @@ import (
 )
 
 const sessionCommandCapacity = 64
+const sessionWriteStallTimeout = 15 * time.Second
 
 type SessionEventKind int
 
@@ -356,10 +357,8 @@ func (s *Session) drainReadable(buffer []byte, assembler *analyzer.CaptureAssemb
 }
 
 // writeAll is reactor-owned and does not report command completion until every
-// byte has been accepted by the nonblocking PTY. The bounded retry deadline
-// turns a saturated terminal into an explicit driver failure.
+// byte has been accepted by the nonblocking PTY.
 func (s *Session) writeAll(payload []byte) error {
-	deadline := time.Now().Add(500 * time.Millisecond)
 	for len(payload) > 0 {
 		count, err := unix.Write(s.fd, payload)
 		if count > 0 {
@@ -374,22 +373,15 @@ func (s *Session) writeAll(payload []byte) error {
 		if !errors.Is(err, syscall.EAGAIN) && !errors.Is(err, syscall.EWOULDBLOCK) {
 			return err
 		}
-		if err := s.waitWritable(deadline); err != nil {
+		if err := s.waitWritable(); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Session) waitWritable(deadline time.Time) error {
-	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		return errors.New("PTY write remained blocked")
-	}
-	timeout := int(remaining.Milliseconds())
-	if timeout == 0 {
-		timeout = 1
-	}
+func (s *Session) waitWritable() error {
+	timeout := int(sessionWriteStallTimeout.Milliseconds())
 	descriptors := []unix.PollFd{{
 		Fd:     int32(s.fd),
 		Events: unix.POLLOUT,
@@ -397,21 +389,16 @@ func (s *Session) waitWritable(deadline time.Time) error {
 	for {
 		ready, err := unix.Poll(descriptors, timeout)
 		if errors.Is(err, syscall.EINTR) {
-			remaining = time.Until(deadline)
-			if remaining <= 0 {
-				return errors.New("PTY write remained blocked")
-			}
-			timeout = int(remaining.Milliseconds())
-			if timeout == 0 {
-				timeout = 1
-			}
 			continue
 		}
 		if err != nil {
 			return fmt.Errorf("wait for PTY write capacity: %w", err)
 		}
-		if ready == 0 || descriptors[0].Revents&unix.POLLOUT == 0 {
-			return errors.New("PTY write remained blocked")
+		if ready == 0 {
+			return fmt.Errorf("PTY write made no progress for %s", sessionWriteStallTimeout)
+		}
+		if descriptors[0].Revents&unix.POLLOUT == 0 {
+			return fmt.Errorf("PTY became unavailable while waiting to write: revents=%d", descriptors[0].Revents)
 		}
 		return nil
 	}

--- a/internal/testharness/pty/driver/types.go
+++ b/internal/testharness/pty/driver/types.go
@@ -10,7 +10,10 @@ import (
 	"github.com/google/uuid"
 )
 
-const maxCommandTimeout = 5 * time.Second
+const (
+	defaultCommandTimeout = 5 * time.Second
+	maxCommandTimeout     = time.Minute
+)
 
 type SessionSpec struct {
 	Path       string

--- a/server/tools/shell/manager_output_test.go
+++ b/server/tools/shell/manager_output_test.go
@@ -2,10 +2,25 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestManagerCollectUntilTreatsExitedProcessAsIncompleteUntilOutputFinalized(t *testing.T) {
+	entry := &processEntry{
+		notify:          make(chan struct{}, 1),
+		outputFinalized: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := (&Manager{}).collectUntil(ctx, entry, time.Now().Add(time.Second))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("collectUntil error = %v, want context canceled while output remains unfinalized", err)
+	}
+}
 
 func TestManagerSubscribeOutputWaitsForLogFlushNotification(t *testing.T) {
 	manager := newBackgroundTestManager(t)

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -476,6 +476,11 @@ func (m *Manager) collectUntil(ctx context.Context, entry *processEntry, deadlin
 			_, _ = collected.Write(pending)
 		}
 		if !entry.isRunning() {
+			select {
+			case <-entry.outputFinalized:
+			case <-ctx.Done():
+				return collected.Bytes(), ctx.Err()
+			}
 			if pending := entry.drainPending(); len(pending) > 0 {
 				_, _ = collected.Write(pending)
 			}

--- a/server/tools/shell/process_unix.go
+++ b/server/tools/shell/process_unix.go
@@ -39,7 +39,16 @@ func terminateManagedProcess(process *os.Process, descendants []managedProcessId
 	}
 	descendantErr := terminateManagedDescendants(descendants)
 	groupErr := signalManagedProcessGroup(process, syscall.SIGTERM, "terminate")
-	_ = process.Signal(os.Interrupt)
+	if groupErr != nil {
+		rootErr := process.Signal(os.Interrupt)
+		if rootErr == nil || errors.Is(rootErr, os.ErrProcessDone) || errors.Is(rootErr, syscall.ESRCH) {
+			groupErr = nil
+		} else {
+			groupErr = errors.Join(groupErr, fmt.Errorf("signal managed root process %d: %w", process.Pid, rootErr))
+		}
+	} else {
+		_ = process.Signal(os.Interrupt)
+	}
 	return errors.Join(descendantErr, groupErr)
 }
 


### PR DESCRIPTION
## Summary
- install the official `just` Windows ARM64 release asset when `setup-just` cannot resolve that runner target
- provision Go in desktop release builds before TypeScript contract generation

## Why
The v2.7.0 autorelease run failed deterministically in the Windows ARM smoke job during `setup-just` and in the macOS desktop job because `go` was unavailable. The release tag exists, but no GitHub release was published.

## Verification
- `just lint --dry-run`
- `git diff --check`
- confirmed the latest official `casey/just` release contains exactly one `aarch64-pc-windows-msvc.zip` asset

After this merges, I will rerun the release workflow against the existing v2.7.0 tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM release validation by installing and checking the correct ARM64 application binary.
  * Added version verification to help detect invalid or incomplete release packages.

* **Chores**
  * Updated desktop build tooling to use the project’s specified Go version.
  * Enabled checks for newer Go versions to support more reliable and up-to-date releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->